### PR TITLE
MERC-111 - Fix text cutoff in search dropdown

### DIFF
--- a/assets/scss/components/stencil/navUser/_navUser.scss
+++ b/assets/scss/components/stencil/navUser/_navUser.scss
@@ -254,6 +254,7 @@
 
     .form-input {
         font-size: fontSize("small");
+        height: unset;
     }
 
     .productGrid {


### PR DESCRIPTION
MERC-111 - Fix text cutoff in search dropdown

* Unset height rule for the dropdown search bar, the results with going with the default height instead of being explicitly sized.