### PR TITLE
MERC-116 - Price fields should be of number type

### DIFF
--- a/templates/components/search/advanced-search.html
+++ b/templates/components/search/advanced-search.html
@@ -48,11 +48,11 @@
                     </p>
                     <label>
                         <span class="u-hiddenVisually">{{lang 'forms.search.price_range' }}</span>
-                        <span>{{lang 'common.from'}}</span><input type="text" class="form-input" name="price_from" id="search-form-price_from" value="{{forms.search.values.price_from}}">
+                        <span>{{lang 'common.from'}}</span><input type="number" class="form-input" name="price_from" id="search-form-price_from" value="{{forms.search.values.price_from}}">
                     </label>
                     <label>
                         <span class="u-hiddenVisually">{{lang 'forms.search.price_range' }}</span>
-                        <span>{{lang 'common.to'}}</span><input type="text" class="form-input" name="price_to" id="search-form-price_to" value="{{forms.search.values.price_to}}">
+                        <span>{{lang 'common.to'}}</span><input type="number" class="form-input" name="price_to" id="search-form-price_to" value="{{forms.search.values.price_to}}">
                     </label>
                 </div>
             </div>

--- a/templates/components/search/advanced-search.html
+++ b/templates/components/search/advanced-search.html
@@ -48,11 +48,11 @@
                     </p>
                     <label>
                         <span class="u-hiddenVisually">{{lang 'forms.search.price_range' }}</span>
-                        <span>{{lang 'common.from'}}</span><input type="number" class="form-input" name="price_from" id="search-form-price_from" value="{{forms.search.values.price_from}}">
+                        <span>{{lang 'common.from'}}</span><input type="number" step="any" class="form-input" name="price_from" id="search-form-price_from" value="{{forms.search.values.price_from}}">
                     </label>
                     <label>
                         <span class="u-hiddenVisually">{{lang 'forms.search.price_range' }}</span>
-                        <span>{{lang 'common.to'}}</span><input type="number" class="form-input" name="price_to" id="search-form-price_to" value="{{forms.search.values.price_to}}">
+                        <span>{{lang 'common.to'}}</span><input type="number" step="any" class="form-input" name="price_to" id="search-form-price_to" value="{{forms.search.values.price_to}}">
                     </label>
                 </div>
             </div>


### PR DESCRIPTION
MERC-116 - Price fields should be of number type

* Change field type to `number` this will prevent unwanted strings from being submitted for price.