### PR TITLE
MERC-108 - Add 'X' to close full screen quick search dropdown.

### DIFF
--- a/assets/js/theme/global/stencil-dropdown.js
+++ b/assets/js/theme/global/stencil-dropdown.js
@@ -66,6 +66,9 @@ export default class StencilDropdown {
             modalOpened = true;
         }).on('close.fndtn.reveal', '[data-reveal]', () => {
             modalOpened = false;
+        }).on('click', '[data-drop-down-close]', () => {
+            modalOpened = false;
+            this.hide($container);
         });
     }
 }

--- a/templates/components/search/quick-results.html
+++ b/templates/components/search/quick-results.html
@@ -1,4 +1,7 @@
 {{#if product_results.products}}
+    <a class="modal-close" aria-label="{{lang 'common.close'}}" data-drop-down-close role="button">
+        <span aria-hidden="true">&#215;</span>
+    </a>
     <ul class="productGrid">
 
         {{#each product_results.products}}


### PR DESCRIPTION
MERC-108 - Add 'X' to close full screen quick search dropdown.

#### Why
Once there are search results it is difficult and unintuitive to close the search results drop down.

#### How
Just added the standard 'X' that we use in modals to display when there are search results. This is bound to the listener with the `data-drop-down-close` data attribute.