### PR TITLE
MERC-456 Update the continue url to point to a new specific url instead of home

### DIFF
--- a/templates/pages/auth/account-created.html
+++ b/templates/pages/auth/account-created.html
@@ -3,7 +3,7 @@
         <main class="page-content page-content--textCenter">
             <h1 class="page-heading">{{lang 'create_account.created.heading'}}</h1>
             <p>{{{lang 'create_account.created.intro' store_name=settings.store_name email=customer.email}}}</p>
-            <a class="button button--primary" href="{{urls.home}}">{{lang 'create_account.created.continue'}}</a>
+            <a class="button button--primary" href="{{create_account.continue_url}}">{{lang 'create_account.created.continue'}}</a>
         </main>
     </section>
 {{/partial}}


### PR DESCRIPTION
## What

Change the url for the "continue" button to point to a specific url instead of to the home url.

## Why

Currently the url doesn't take redirects during account signup into account, which means adding to wishlist while not signed in doesn't work when you create an account (among other things).

Ping @hegrec @mickr @mcampa 