### PR TITLE
MERC-581 - adding support for hidden throttle token to product review modal

### DIFF
--- a/templates/components/products/modals/writeReview.html
+++ b/templates/components/products/modals/writeReview.html
@@ -66,6 +66,7 @@
                 </div>
                 <input type="hidden" name="product_id" value="{{ product.id }}">
                 <input type="hidden" name="action" value="post_review">
+                {{#if product.reviews.throttleToken}}<input type="hidden" name="throttleToken" value="{{product.reviews.throttleToken}}">{{/if}}
             </fieldset>
         </form>
     </div>


### PR DESCRIPTION
Without this, the throttle token won't be sent to BC App, and it will consider all "throttled" requests to be invalid.