### PR TITLE
MERC-410: Improve gallery image size

### DIFF
--- a/config.json
+++ b/config.json
@@ -75,8 +75,8 @@
         "height": 659
       },
       "gallery": {
-        "width": 190,
-        "height": 250
+        "width": 300,
+        "height": 300
       },
       "zoom": {
         "width": 1280,

--- a/templates/components/products/card.html
+++ b/templates/components/products/card.html
@@ -1,7 +1,7 @@
 <article class="card {{#if alternate}}card--alternate{{/if}}">
     <figure class="card-figure">
         <a href="{{url}}">
-            <img class="card-image" src="{{getImage image 'product' (cdn theme_settings.default_image_product)}}" alt="{{image.alt}}">
+            <img class="card-image" src="{{getImage image 'gallery' (cdn theme_settings.default_image_product)}}" alt="{{image.alt}}">
         </a>
         <figcaption class="card-figcaption">
             <div class="card-figcaption-body">


### PR DESCRIPTION
## What
Use the gallery image size and also bump it up slightly to prevent blurry images

## Why
The `product` preset is much larger than the css limited size of card images. They are never larger than 300px across all responsive widths so this appears to be an appropriate size.

## Screenshots

### Before
![](https://dl.dropboxusercontent.com/spa/jd5nszcz7axrfas/wfnanmh_.png)

### After
![](https://dl.dropboxusercontent.com/spa/jd5nszcz7axrfas/-s5ulme2.png)


@sherrybc @bc-ejoe @mickr @mcampa 