### PR TITLE
MERC-662: Transpile Object.assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "babel-core": "6.7.4",
     "babel-eslint": "4.1.0",
     "babel-loader": "6.2.4",
+    "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "es6-shim": "0.35.0",
     "eslint-config-airbnb": "^6.0.2",

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -12,7 +12,8 @@ module.exports = {
                 query: {
                     compact: false,
                     cacheDirectory: true,
-                    presets: ['es2015']
+                    presets: ['es2015'],
+                    plugins: ['transform-object-assign']
                 }
             }
         ]


### PR DESCRIPTION
## What
Babel 6 does not transpile object.assign automatically so we need to include this plugin.


@mcampa @bc-ejoe @mickr @sherrybc 