### PR TITLE
MERC-691: revert back to slick-carousel v1.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lodash": "^3.5.0",
     "nod-validate": "^2.0.12",
     "pace": "hubspot/pace",
-    "slick-carousel": "^1.5.9",
+    "slick-carousel": "1.5.5",
     "time-grunt": "^1.2.2",
     "webpack": "^1.12.14"
   }


### PR DESCRIPTION
## What?

Fix for missing previous slide arrow on the carousel by reverting back to slick-carousel v1.5.5.  


## Why?

Prior to 328cf24, v1.5.5 was being pulled in.  v1.5.6 of the lib introduced a change to the dom location of the arrow, causing the z-index to be lower than the carousel image.

## Testing/Proof

before:
![screen shot 2016-05-11 at 1 19 42 am](https://cloud.githubusercontent.com/assets/7851919/15174433/91660ade-1716-11e6-8690-c88ae4b50780.png)


after:
![screen shot 2016-05-11 at 1 19 16 am](https://cloud.githubusercontent.com/assets/7851919/15174438/987fb13a-1716-11e6-9b5b-395492187d19.png)

@hegrec @mickr @sherrybc @mcampa 