### PR TITLE
Remove repetitive data attribute from cart table

### DIFF
--- a/templates/components/cart/content.html
+++ b/templates/components/cart/content.html
@@ -1,4 +1,4 @@
-<table class="cart" data-cart-content data-cart-quantity="{{cart.quantity}}">
+<table class="cart" data-cart-quantity="{{cart.quantity}}">
     <thead class="cart-header">
         <tr>
             <th class="cart-header-item" colspan="2">{{lang 'cart.checkout.item'}}</th>


### PR DESCRIPTION
The cart table should not have the `data-cart-content` attribute. That attribute is already present on the div that wraps the cart content component in the `page/cart.html` file.

This attribute causes the cart not to function as expected when the last product is removed from the cart after previously removing other products. As an example, put 2 products in your cart. Remove one, then remove the last. The page is supposed to refresh after the last item is removed, but it doesn't.

This pull request fixes that problem.