### PR TITLE
MERC-893: update the view in quick view modal if product has options

### DIFF
--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -35,8 +35,23 @@ export default class Product {
         this.imageGallery.init();
         this.listenQuantityChange();
         this.initRadioAttributes();
-        this.updateProductAttributes(productAttributesData);
-        this.updateView(productAttributesData);
+
+        const $form = $('form[data-cart-item-add]', $scope);
+        const hasOptions = $('[data-product-option-change]', $form).html().trim().length;
+
+        // Update product attributes. If we're in quick view and the product has options, then also update the initial view in case items are oos
+        if (_.isEmpty(productAttributesData) && hasOptions) {
+            const $productId = $('[name="product_id"]', $form).val();
+
+            utils.api.productAttributes.optionChange($productId, $form.serialize(), (err, response) => {
+                const attributesData = response.data || {};
+
+                this.updateProductAttributes(attributesData);
+                this.updateView(attributesData);
+            });
+        } else {
+            this.updateProductAttributes(productAttributesData);
+        }
 
         previewModal = modalFactory('#previewModal')[0];
         productSingleton = this;


### PR DESCRIPTION
## What?

Fix for 'Add to Cart' button in quick view modal being disabled.  


## Why?

`window.BCData` does not get set for the quick view modal, so the call to `updateView` would disable the 'Add to Cart' button.  Updated so that product attributes are updated when the product has options, and then the view gets updated.  (related to MERC-678)

## Testing/Proof

![screen shot 2016-07-08 at 4 08 55 pm](https://cloud.githubusercontent.com/assets/7851919/16703905/5a2cb8ae-4526-11e6-8be2-bd0572c29300.png)
![screen shot 2016-07-08 at 11 25 55 am](https://cloud.githubusercontent.com/assets/7851919/16697502/c6d6bf4a-44fe-11e6-8d3a-3ad6e7a07130.png)

@mcampa @hegrec @sherrybc @bc-ranji 