### PR TITLE
V1.3.0

### DIFF
--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -35,8 +35,23 @@ export default class Product {
         this.imageGallery.init();
         this.listenQuantityChange();
         this.initRadioAttributes();
-        this.updateProductAttributes(productAttributesData);
-        this.updateView(productAttributesData);
+
+        const $form = $('form[data-cart-item-add]', $scope);
+        const hasOptions = $('[data-product-option-change]', $form).html().trim().length;
+
+        // Update product attributes. If we're in quick view and the product has options, then also update the initial view in case items are oos
+        if (_.isEmpty(productAttributesData) && hasOptions) {
+            const $productId = $('[name="product_id"]', $form).val();
+
+            utils.api.productAttributes.optionChange($productId, $form.serialize(), (err, response) => {
+                const attributesData = response.data || {};
+
+                this.updateProductAttributes(attributesData);
+                this.updateView(attributesData);
+            });
+        } else {
+            this.updateProductAttributes(productAttributesData);
+        }
 
         previewModal = modalFactory('#previewModal')[0];
         productSingleton = this;

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -112,12 +112,12 @@ export default class Product {
         if (_.isPlainObject(image)) {
             const zoomImageUrl = utils.tools.image.getSrc(
                 image.data,
-                this.context.themeImageSizes.zoom
+                this.context.themeSettings.zoom_size
             );
 
             const mainImageUrl = utils.tools.image.getSrc(
                 image.data,
-                this.context.themeImageSizes.product
+                this.context.themeSettings.product_size
             );
 
             this.imageGallery.setAlternateImage({

--- a/assets/scss/components/citadel/cards/_cards.scss
+++ b/assets/scss/components/citadel/cards/_cards.scss
@@ -42,7 +42,9 @@
 
 .card-image {
     border: 0;
-    width: 100%;
+    display: flex;
+    margin: auto;
+    width: auto;
 }
 
 .card-title {

--- a/assets/scss/components/stencil/account/_account.scss
+++ b/assets/scss/components/stencil/account/_account.scss
@@ -41,6 +41,10 @@
     img {
         width: 100%;
     }
+
+    .account-product-image {
+        width: auto;
+    }
 }
 
 .account-listShipping {
@@ -62,6 +66,9 @@
 }
 
 .account-product-figure {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
     margin: 0 spacing("single") + spacing("third") 0 0;
     position: relative;
     width: 70px;

--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -122,6 +122,10 @@ $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-sp
     }
 }
 
+.cart-item-fixed-image {
+    width: 100%;
+}
+
 .cart-item-title {
     display: table-cell;
     height: $cart-thumbnail-height;

--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -85,7 +85,7 @@ $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-sp
     }
 
     img {
-        width: 100%;
+        width: auto;
     }
 }
 

--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -83,10 +83,6 @@ $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-sp
             display: none;
         }
     }
-
-    img {
-        width: auto;
-    }
 }
 
 .cart-item-block {
@@ -124,6 +120,10 @@ $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-sp
 
 .cart-item-fixed-image {
     width: 100%;
+}
+
+.cart-item-image {
+    width: auto;
 }
 
 .cart-item-title {

--- a/assets/scss/components/stencil/previewCart/_previewCart.scss
+++ b/assets/scss/components/stencil/previewCart/_previewCart.scss
@@ -12,7 +12,7 @@
     @include breakpoint("medium") {
         .productView {
             @include grid-column(9);
-            display: block;
+            display: flex;
             margin: 0;
             padding-bottom: 0;
             padding-top: 0;
@@ -20,6 +20,14 @@
 
         .productView-image {
             @include grid-column(7);
+            display: flex;
+            flex-direction: column;
+        }
+
+        .productView-image--cart {
+            align-self: flex-start;
+            margin: 0 auto;
+            width: auto;
         }
 
         .productView-details {

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -19,16 +19,21 @@
 }
 
 .productView-image {
+    align-items: center;
+    display: flex;
+    justify-content: center;
     margin: 0;
+
+    @include breakpoint("medium") {
+        min-height: 500px;
+        min-width: 500px;
+    }
 
     img {
         width: 100%;
     }
 
     .productView-image--default {
-        display: flex;
-        margin: auto;
-        padding: 50% 0;
         width: auto;
     }
 

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -25,6 +25,13 @@
         width: 100%;
     }
 
+    .productView-image--default {
+        display: flex;
+        margin: auto;
+        padding: 50% 0;
+        width: auto;
+    }
+
     + .productView-thumbnails {
         margin-top: spacing("half");
     }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "devDependencies": {
     "@bigcommerce/citadel": "^2.11.5",
-    "@bigcommerce/stencil-utils": "1.0.4",
+    "@bigcommerce/stencil-utils": "1.0.5",
     "async": "^1.5.2",
     "babel-core": "6.7.4",
     "babel-eslint": "4.1.0",

--- a/templates/components/account/order-contents.html
+++ b/templates/components/account/order-contents.html
@@ -23,7 +23,9 @@
                 {{#if type '===' 'giftcertificate'}}
                     <img class="cart-item-image" src="{{cdn ../../theme_settings.default_image_gift_certificate}}" alt="GiftCertificate">
                 {{else}}
-                    <img src="{{getImage image 'productthumb_size' (cdn ../../theme_settings.default_image_product)}}" alt="{{image.alt}}">
+                    <img class="account-product-image"
+                         src="{{getImage image 'productthumb_size' (cdn ../../theme_settings.default_image_product)}}"
+                         alt="{{image.alt}}">
                 {{/if}}
                 {{#unless refunded}}
                     {{#if download_url}}

--- a/templates/components/account/order-contents.html
+++ b/templates/components/account/order-contents.html
@@ -21,7 +21,7 @@
             </div>
             <figure class="account-product-figure">
                 {{#if type '===' 'giftcertificate'}}
-                    <img class="cart-item-image" src="{{cdn ../../theme_settings.default_image_gift_certificate}}" alt="GiftCertificate">
+                    <img src="{{cdn ../../theme_settings.default_image_gift_certificate}}" alt="GiftCertificate">
                 {{else}}
                     <img class="account-product-image"
                          src="{{getImage image 'productthumb_size' (cdn ../../theme_settings.default_image_product)}}"

--- a/templates/components/account/orders-list.html
+++ b/templates/components/account/orders-list.html
@@ -8,7 +8,9 @@
                 {{#if items.0.type '===' 'giftcertificate'}}
                     <img src="{{cdn ../../theme_settings.default_image_gift_certificate}}" alt="GiftCertificate">
                 {{else}}
-                    <img src="{{getImage image 'productthumb_size' (cdn ../theme_settings.default_image_product)}}" alt="{{image.alt}}">
+                    <img class="account-product-image"
+                         src="{{getImage image 'productthumb_size' (cdn ../theme_settings.default_image_product)}}"
+                         alt="{{image.alt}}">
                 {{/if}}
             </div>
             <div class="account-product-body">

--- a/templates/components/cart/content.html
+++ b/templates/components/cart/content.html
@@ -12,7 +12,7 @@
             <tr class="cart-item" data-item-row>
                 <td class="cart-item-block cart-item-figure">
                     {{#if type '==' 'GiftCertificate'}}
-                        <img class="cart-item-image" src="{{cdn ../../theme_settings.default_image_gift_certificate}}" alt="GiftCertificate">
+                        <img class="cart-item-fixed-image" src="{{cdn ../../theme_settings.default_image_gift_certificate}}" alt="GiftCertificate">
                     {{else}}
                         <img class="cart-item-image" src="{{getImage image 'productthumb_size' (cdn ../../theme_settings.default_image_product)}}" alt="{{image.alt}}">
                     {{/if}}
@@ -133,7 +133,6 @@
                                 <svg><use xlink:href="#icon-close"></use></svg>
                             </a>
                         {{/if}}
-                        <span class="cart-remove cart-remove--spacer"></span>
                     {{/if}}
                 </td>
             </tr>

--- a/templates/components/cart/preview.html
+++ b/templates/components/cart/preview.html
@@ -42,7 +42,9 @@
         <section class="productView">
             {{#with cart.added_item}}
                 <figure class="productView-image">
-                    <img src="{{getImage image 'product_size' (cdn ../theme_settings.default_image_product)}}" alt="{{image.alt}}" />
+                    <img class="productView-image--cart"
+                         src="{{getImage image 'product_size' (cdn ../theme_settings.default_image_product)}}"
+                         alt="{{image.alt}}" />
                 </figure>
 
                 <div class="productView-details">

--- a/templates/components/faceted-search/facets/hierarchy-children.html
+++ b/templates/components/faceted-search/facets/hierarchy-children.html
@@ -4,6 +4,7 @@
             <a
             href="{{url}}"
             class="navList-action navList-action--checkbox {{#if selected }} is-selected {{/if}} {{#if has_sub_categories }} has-children {{/if}}"
+            rel="nofollow"
             data-id="{{ id }}"
             data-faceted-search-facet>
                 {{title}}

--- a/templates/components/faceted-search/facets/hierarchy.html
+++ b/templates/components/faceted-search/facets/hierarchy.html
@@ -28,6 +28,7 @@
                     <a
                         href="{{url}}"
                         class="navList-action navList-action--checkbox {{#if selected }} is-selected {{/if}} {{#if has_sub_categories }} has-children {{/if}}"
+                        rel="nofollow"
                         data-id="{{ id }}"
                         data-faceted-search-facet>
                         {{ title }}

--- a/templates/components/faceted-search/facets/multi.html
+++ b/templates/components/faceted-search/facets/multi.html
@@ -28,6 +28,7 @@
                     <a
                         href="{{ url }}"
                         class="navList-action navList-action--checkbox {{#if selected }} is-selected {{/if}}"
+                        rel="nofollow"
                         data-faceted-search-facet>
                         {{ title }}
                         {{#if ../show_product_counts}}

--- a/templates/components/faceted-search/facets/rating.html
+++ b/templates/components/faceted-search/facets/rating.html
@@ -25,7 +25,10 @@
         <ul class="navList">
             {{#each items}}
                 <li class="navList-item">
-                    <a href="{{ url }}" class="navList-action navList-action--checkbox {{#if selected }} is-selected {{/if}}" data-faceted-search-facet>
+                    <a href="{{ url }}"
+                       class="navList-action navList-action--checkbox {{#if selected }} is-selected {{/if}}"
+                       rel="nofollow"
+                       data-faceted-search-facet>
                         <span class="rating--small">
                             {{> components/products/ratings rating=title}}
                         </span>

--- a/templates/components/faceted-search/selected-facets.html
+++ b/templates/components/faceted-search/selected-facets.html
@@ -10,6 +10,7 @@
                     <a
                         href="{{ url }}"
                         class="facetLabel"
+                        rel="nofollow"
                         data-faceted-search-facet>
                         {{#if facet '===' 'rating'}}
                             {{lang 'search.faceted.selected.rating-label' rating=title}}

--- a/templates/components/faceted-search/show-more-facets.html
+++ b/templates/components/faceted-search/show-more-facets.html
@@ -12,6 +12,7 @@
                     <li class="navList-item"><a
                         href="{{url}}"
                         class="navList-action {{#if selected }} is-active {{/if}}"
+                        rel="nofollow"
                         data-id="{{ id }}"
                         data-faceted-search-facet>{{title}} ({{count}})</a></li>
                 {{/each}}

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -153,7 +153,9 @@
                 data-zoom-image="{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}"
                 >
             <a href="{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}">
-                <img src="{{getImage product.main_image 'product_size' (cdn theme_settings.default_image_product)}}" alt="{{product.main_image.alt}}" data-main-image>
+                <img class="productView-image--default"
+                     src="{{getImage product.main_image 'product_size' (cdn theme_settings.default_image_product)}}"
+                     alt="{{product.main_image.alt}}" data-main-image>
             </a>
         </figure>
         <ul class="productView-thumbnails">

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -14,7 +14,7 @@
         {{{head.scripts}}}
         {{{head.rsslinks}}}
 
-        {{inject 'themeImageSizes' theme_settings._images}}
+        {{inject 'themeSettings' theme_settings}}
         {{inject 'genericError' (lang 'common.generic_error')}}
         {{inject 'maintenanceMode' settings.maintenance}}
         {{inject 'urls' urls}}


### PR DESCRIPTION
At the bottom of [this page](https://stencil.bigcommerce.com/docs/custom-handlebars-helpers), it says to create pull requests for suggestions on custom handlebar helpers. 

I am working on a site that has a unique design on products, and the product names should not exceed a certain length. I had to do this with JS after page load, since I am not able to create custom handlebars in Stencil. This resulted in the page flickering when the JS did it's magic, since as a result of reducing the product name length, it also shrunk the product height overall.

Please allow custom helpers, and if not, please allow another way we can add functionality that will happen at the rendering of components, as opposed to after the page has loaded.

Here is my suggestion (a simple function, similar to that of substr in php):

```
Handlebars.registerHelper('substr', function(str, start, length, concat) {
    var _start  = start  || 0,
        _length = length || 100,
        _concat = concat || null;

    if (str.length < _length) {
        return str;
    }

    var newStr = str.substr(_start, _length - 1 );

    if (_concat) {
        newStr = newStr + _concat;
    }

    return newStr;
});
```

The helper above can be used like:

```
// This is a random string!
// {{substr someString 0 10 '...'}}
// This is a ...
```

This would be greatly appreciated.

I don't even see where I can make an edit/push up here for review..there is no mention of Handlebars (not the kind I need anyways) in the entire stencil repo.

Thanks a lot!