### PR TITLE
CHECKOUT-919: add main content uco customizations

### DIFF
--- a/assets/scss/checkout.scss
+++ b/assets/scss/checkout.scss
@@ -1,3 +1,73 @@
 // =============================================================================
 // Stencil Checkout  - Customize the checkout experience
 // =============================================================================
+
+// Main content
+.ng-checkout-container {
+    background-color: stencilColor("uco_main_backgroundColor");
+}
+
+// Order Summary
+.cart {
+    background-color: stencilColor("uco_cart_backgroundColor");
+}
+
+// Typography
+
+$fontFamily-headings:           stencilFontFamily("uco_headings_font"), Arial, Helvetica, sans-serif;
+$fontFamily-sans:               stencilFontFamily("uco_body_font"), Arial, Helvetica, sans-serif;
+
+// Headings
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    font-family: $fontFamily-headings;
+}
+
+// Body
+body {
+    font-family: $fontFamily-sans;
+}
+
+// Links
+a {
+    color: stencilColor("uco_links_color");
+}
+
+// Buttons
+.button {
+    background-color: stencilColor("uco_buttons_color");
+}
+
+// Errors
+.form-field--error {
+
+    .form-input,
+    .form-select,
+    .form-checkbox + .form-label::before,
+    .form-radio + .form-label::before,
+    .form-prefixPostfix-label {
+        border-color: stencilColor("uco_errors_color");
+    }
+
+    .form-field-error,
+    .form-inlineMessage {
+        color: stencilColor("uco_errors_color");
+    }
+
+    // Depth need to style svg with validation state
+    // scss-lint:disable SelectorDepth
+    .form-input-indicator > svg {
+        fill: stencilColor("uco_errors_color");
+    }
+    // scss-lint:enable SelectorDepth
+}
+
+// Form Fields
+.form-legend,
+.form-body {
+    background-color: stencilString("uco_form-field_backgroundColor");
+}

--- a/config.json
+++ b/config.json
@@ -37,6 +37,14 @@
     "last 3 versions"
   ],
   "settings": {
+    "uco_main_backgroundColor": "#ffffff",
+    "uco_cart_backgroundColor": "#ffffff",
+    "uco_headings_font": "Google_Montserrat_400",
+    "uco_body_font": "Google_Karla_400",
+    "uco_links_color": "#f010da",
+    "uco_buttons_color": "#f010da",
+    "uco_errors_color": "#f010da",
+    "uco_form-field_backgroundColor": "white",
     "homepage_new_products_count": 12,
     "homepage_featured_products_count": 8,
     "homepage_top_products_count": 8,

--- a/schema.json
+++ b/schema.json
@@ -1462,6 +1462,117 @@
     ]
   },
   {
+    "name": "Checkout",
+    "settings": [
+      {
+        "type": "heading",
+        "content": "Main content area"
+      },
+      {
+        "type": "color",
+        "label": "Background color",
+        "id": "uco_main_backgroundColor"
+      },
+      {
+        "type": "heading",
+        "content": "Order Summary"
+      },
+      {
+        "type": "color",
+        "label": "Background color",
+        "id": "uco_cart_backgroundColor"
+      },
+      {
+        "type": "heading",
+        "content": "Typography"
+      },
+      {
+        "type": "font",
+        "label": "Headings",
+        "id": "uco_headings_font",
+        "options": [
+          {
+            "group": "Montserrat",
+            "label": "Montserrat",
+            "value": "Google_Montserrat_400"
+          },
+          {
+            "group": "Open Sans",
+            "label": "Open Sans",
+            "value": "Google_Open+Sans_400"
+          },
+          {
+            "group": "Open Sans",
+            "label": "Open Sans Bold",
+            "value": "Google_Open+Sans_700"
+          },
+          {
+            "group": "Roboto",
+            "label": "Roboto",
+            "value": "Google_Roboto_400"
+          },
+          {
+            "group": "Volkhov",
+            "label": "Volkhov",
+            "value": "Google_Volkhov_400"
+          }
+        ]
+      },
+      {
+        "type": "font",
+        "label": "Body",
+        "id": "uco_body_font",
+        "options": [
+          {
+            "group": "Karla",
+            "label": "Karla",
+            "value": "Google_Karla_400"
+          },
+          {
+            "group": "Roboto",
+            "label": "Roboto",
+            "value": "Google_Roboto_400"
+          },
+          {
+            "group": "Source Sans Pro",
+            "label": "Source Sans Pro",
+            "value": "Google_Source+Sans+Pro_400"
+          }
+        ]
+      },
+      {
+        "type": "color",
+        "label": "Links",
+        "id": "uco_links_color"
+      },
+      {
+        "type": "color",
+        "label": "Buttons",
+        "id": "uco_buttons_color"
+      },
+      {
+        "type": "color",
+        "label": "Errors",
+        "id": "uco_errors_color"
+      },
+      {
+        "type": "select",
+        "label": "Form Fields",
+        "id": "uco_form-field_backgroundColor",
+        "options": [
+          {
+            "value": "white",
+            "label": "White"
+          },
+          {
+            "value": "transparent",
+            "label": "Transparent"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "name": "Footer",
     "settings": [
       {


### PR DESCRIPTION
ability to change background color
Ability to update Typography via existing style editor features under 'Backgrounds & Fonts"
*Page Text	
*Heading	
*Heading Text
update form fields color

<img width="1395" alt="screen shot 2016-08-23 at 6 57 07 pm" src="https://cloud.githubusercontent.com/assets/8165665/17915937/6e8ddc4a-6963-11e6-9c78-c42ecf2c7c8d.png">

@bigcommerce/checkout @sherrybc @mcampa @bc-ong 