### PR TITLE
BIG-27748: Cornerstone Light, Bold, Warm fix of Amazon button placement

### DIFF
--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -485,6 +485,7 @@ $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-sp
 
     .button {
         display: block;
+        margin-bottom: 0;
 
         @include breakpoint("small") {
             display: inline-block;
@@ -504,11 +505,11 @@ $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-sp
         p {
             // scss-lint:disable ImportantRule
             float: none !important;
-            margin-bottom: spacing("quarter");
+            margin: spacing("third") 0;
             text-align: right;
         }
 
-        form {
+        div {
             float: right;
         }
     }

--- a/assets/scss/components/stencil/previewCart/_previewCart.scss
+++ b/assets/scss/components/stencil/previewCart/_previewCart.scss
@@ -80,6 +80,7 @@
     p {
         // scss-lint:disable ImportantRule
         float: none !important; // 1
+        margin: spacing("third") 0;
     }
 }
 


### PR DESCRIPTION
## What?
Fixing Pay with Amazon button position for Cornerstone themes and using new `RemoteCheckout` class for unification.

## Why?
Because it looks ugly otherwise.

## Testing
### Cornerstone Bold (cart)
![boldcart](https://cloud.githubusercontent.com/assets/5741553/18237826/749bf58e-7379-11e6-89f3-384b36d39b01.png)
### Cornerstone Bold (fast cart popup)
![boldpopup](https://cloud.githubusercontent.com/assets/5741553/18237827/749e126a-7379-11e6-9e3f-ef63d9e9c272.png)
### Cornerstone Light (cart)
![lightcart](https://cloud.githubusercontent.com/assets/5741553/18237828/749fa224-7379-11e6-9614-cc505f73c81f.png)
### Cornerstone Light (fast cart popup)
![lightpopup](https://cloud.githubusercontent.com/assets/5741553/18237830/74a23246-7379-11e6-9625-034885fc2475.png)
### Cornerstone Warm (cart)
![warmcart](https://cloud.githubusercontent.com/assets/5741553/18237829/74a18fee-7379-11e6-9942-4296907949bc.png)
### Cornerstone Warm (fast cart popup)
![warmpopup](https://cloud.githubusercontent.com/assets/5741553/18237831/74f65664-7379-11e6-94a0-f2575a4e00cb.png)

ping @davidchin, @bc-miko-ademagic, @bigcommerce/payments