### PR TITLE
CHECKOUT-1016: Expose links to multi-address checkout.

### DIFF
--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -492,6 +492,13 @@ $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-sp
             float: right;
         }
     }
+
+    .checkoutMultiple {
+        clear: right;
+        display: block;
+        float: right;
+        padding-top: spacing("quarter");
+    }
 }
 
 .cart-additionalCheckoutButtons { // 1
@@ -604,6 +611,12 @@ $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-sp
 
 .previewCartAction-checkout {
     padding-right: spacing("quarter");
+}
+
+.previewCartAction-checkoutMultiple {
+    clear: both;
+    padding-left: spacing("half");
+    padding-top: spacing("quarter");
 }
 
 .previewCartAction-viewCart {

--- a/lang/en.json
+++ b/lang/en.json
@@ -55,6 +55,7 @@
         },
         "preview": {
             "checkout_now": "Checkout Now",
+            "checkout_multiple": "or checkout with multiple addresses",
             "view_cart": "View Cart"
         },
         "label": "Your Cart ({quantity, plural, one {# item} other {# items}})",

--- a/templates/components/cart/preview.html
+++ b/templates/components/cart/preview.html
@@ -19,6 +19,14 @@
                 {{/each}}
             </div>
 
+            {{#if cart.show_multiple_address_shipping}}
+                <div class="previewCartAction-checkoutMultiple">
+                    <a href="{{urls.checkout.multiple_address}}">
+                        {{lang 'cart.preview.checkout_multiple'}}
+                    </a>
+                </div>
+            {{/if}}
+
             <div class="previewCartCheckout-subtotal">
                 {{lang 'cart.added_to_cart.order_subtotal'}}
 

--- a/templates/components/common/cart-preview.html
+++ b/templates/components/common/cart-preview.html
@@ -44,6 +44,14 @@
                     {{lang 'cart.preview.view_cart'}}
                 </a>
             </div>
+
+            {{#if cart.show_multiple_address_shipping}}
+                <div class="previewCartAction-checkoutMultiple">
+                    <a href="{{urls.checkout.multiple_address}}">
+                        {{lang 'cart.preview.checkout_multiple'}}
+                    </a>
+                </div>
+            {{/if}}
         </div>
     {{else}}
         <div class="previewCart-emptyBody">

--- a/templates/pages/cart.html
+++ b/templates/pages/cart.html
@@ -24,6 +24,11 @@
             {{#if cart.show_primary_checkout_button}}
                 <div class="cart-actions">
                     <a class="button button--primary" href="{{urls.checkout.single_address}}" title="{{lang 'cart.checkout.title'}}">{{lang 'cart.checkout.button'}}</a>
+                    {{#if cart.show_multiple_address_shipping}}
+                        <a class="checkoutMultiple" href="{{urls.checkout.multiple_address}}">
+                            {{lang 'cart.preview.checkout_multiple'}}
+                        </a>
+                    {{/if}}
                 </div>
             {{else}}
                 <div class="cart-actions">


### PR DESCRIPTION
## What?
Consume the new field exposed in https://github.com/bigcommerce/bigcommerce/pull/15145 to display links to checkout with support for multiple addresses.

## Why?
Merchant demand.

## Testing / Proof
Home page cart popup:
<img width="334" alt="screen shot 2016-09-19 at 9 25 56 am" src="https://cloud.githubusercontent.com/assets/813373/18619985/99ba5198-7e4c-11e6-8a3b-27eef184cf65.png">

Full cart page:
<img width="646" alt="screen shot 2016-09-19 at 9 31 51 am" src="https://cloud.githubusercontent.com/assets/813373/18619984/99b88d36-7e4c-11e6-84f2-f748dc3e8165.png">

Product page added to cart popup:
<img width="1066" alt="screen shot 2016-09-19 at 9 35 49 am" src="https://cloud.githubusercontent.com/assets/813373/18619986/99ba626e-7e4c-11e6-9173-f47b9f7bd30d.png">
