### PR TITLE
Use CSS to position maintenance banner

### DIFF
--- a/assets/js/theme/global/maintenanceMode.js
+++ b/assets/js/theme/global/maintenanceMode.js
@@ -8,8 +8,6 @@ export default function (maintenanceMode = {}) {
     const header = maintenanceMode.header;
     const notice = maintenanceMode.notice;
 
-    let scrollTop = 0;
-
     if (!(header && notice)) {
         return;
     }
@@ -22,22 +20,4 @@ export default function (maintenanceMode = {}) {
     $element.html(`<p class="maintenanceNotice-header">${header}</p>${notice}`);
 
     $('body').append($element);
-
-    $(window)
-        .bind('scroll', () => {
-            $element.css('top', `${($('body').scrollTop() + scrollTop)}px`);
-        })
-        .bind('resize', () => {
-            const menuWidth = $('#maintenance-notice').width();
-
-            if (menuWidth + $('#maintenance-notice').offset().left > $(window).width()) {
-                const newLeft = (`${$(window).width() - menuWidth - 50}px`);
-
-                $('#maintenance-notice').css('left', newLeft);
-            }
-        });
-
-    scrollTop = $('#maintenance-notice').scrollTop() - $('body').scrollTop();
-
-    $(window).trigger('resize');
 }


### PR DESCRIPTION
## What?
* Use CSS only to position maintenance banner.

## Why?
* Currently, we use both JS and CSS to position the maintenance banner. They conflict with each other. Therefore, the banner goes out of position when you scroll.
* For your reference, these are the original commits. As you can see, JS solution was implemented first. And then few days later, a different engineer introduced the CSS change.:
  * https://github.com/bigcommerce/stencil/commit/4ab7648598622ec8b0ac4a379e102f185b350b4c
  * https://github.com/bigcommerce/stencil/commit/44a0757fc05d6b0c7412ad5236ae7f97588e3f90
* Existing CSS here: https://github.com/bigcommerce/stencil/blob/master/assets/scss/components/stencil/maintenanceNotice/_maintenanceNotice.scss

## Testing / Proof
|Before|After|   
|---|---|
|![screen shot 2016-09-28 at 12 26 22 pm](https://cloud.githubusercontent.com/assets/667603/18898734/e57adea0-8576-11e6-9f0c-95c3821cfd1b.png)|![screen shot 2016-09-28 at 12 26 39 pm](https://cloud.githubusercontent.com/assets/667603/18898741/ed58d7c6-8576-11e6-8546-8fc2b867ff7f.png)|

@mcampa @sherrybc @icatalina @PascalZajac 
