### PR TITLE
MERC-1272 Replace history.js with html5 history api shim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .DS_Store
 assets/css-artifacts
 assets/js/bundle.js
+assets/js/bundle.js.map

--- a/assets/js/test-unit/theme/common/faceted-search.spec.js
+++ b/assets/js/test-unit/theme/common/faceted-search.spec.js
@@ -2,7 +2,8 @@ import FacetedSearch from '../../../theme/common/faceted-search';
 import { Validators } from '../../../theme/common/form-utils';
 import $ from 'jquery';
 import { hooks, api } from '@bigcommerce/stencil-utils';
-import 'history.js/scripts/bundled-uncompressed/html4+html5/jquery.history';
+import urlUtils from '../../../theme/common/url-utils';
+
 describe('FacetedSearch', () => {
     let facetedSearch;
     let requestOptions;
@@ -98,26 +99,20 @@ describe('FacetedSearch', () => {
 
     describe('updateView', () => {
         let content;
-        let state;
+        const url = '/current/path?facet=1';
 
         beforeEach(() => {
             spyOn(api, 'getPage');
-            spyOn(History, 'getState');
             spyOn(facetedSearch, 'refreshView');
-
-            state = {
-                url: 'http://url.com/slug',
-            };
+            spyOn(urlUtils, 'getUrl').and.returnValue(url);
 
             content = {};
-
-            History.getState.and.returnValue(state);
         });
 
         it('should fetch content from remote server', function() {
             facetedSearch.updateView();
 
-            expect(api.getPage).toHaveBeenCalledWith(state.url, requestOptions, jasmine.any(Function));
+            expect(api.getPage).toHaveBeenCalledWith(url, requestOptions, jasmine.any(Function));
         });
 
         it('should refresh view', function() {
@@ -174,22 +169,20 @@ describe('FacetedSearch', () => {
     });
 
     describe('when location URL is changed', () => {
-        let title;
         let href;
 
         beforeEach(() => {
-            title = document.title;
             href = document.location.href;
 
             spyOn(facetedSearch, 'updateView');
         });
 
         afterEach(() => {
-            History.pushState({}, title, href);
+            urlUtils.goToUrl(href);
         });
 
         it('should update view', () => {
-            History.pushState({}, 'Hello World', '/hello-world');
+            urlUtils.goToUrl('/hello-world');
 
             expect(facetedSearch.updateView).toHaveBeenCalled();
         });
@@ -206,21 +199,21 @@ describe('FacetedSearch', () => {
                 preventDefault: jasmine.createSpy('preventDefault'),
             };
 
-            spyOn(History, 'pushState');
+            spyOn(urlUtils, 'goToUrl');
             spyOn(facetedSearch.priceRangeValidator, 'areAll').and.returnValue(true);
         });
 
         it('should set `min_price` and `max_price` query param to corresponding form values if form is valid', () => {
             hooks.emit(eventName, event);
 
-            expect(History.pushState).toHaveBeenCalledWith({}, '', '/context.html?min_price=0&max_price=100');
+            expect(urlUtils.goToUrl).toHaveBeenCalledWith('/context.html?min_price=0&max_price=100');
         });
 
         it('should not set `min_price` and `max_price` query param to corresponding form values if form is invalid', () => {
             facetedSearch.priceRangeValidator.areAll.and.returnValue(false);
             hooks.emit(eventName, event);
 
-            expect(History.pushState).not.toHaveBeenCalledWith({}, '', '/context.html?min_price=0&max_price=100');
+            expect(urlUtils.goToUrl).not.toHaveBeenCalled();
         });
 
         it('should prevent default event', function() {
@@ -241,13 +234,13 @@ describe('FacetedSearch', () => {
                 preventDefault: jasmine.createSpy('preventDefault'),
             };
 
-            spyOn(History, 'pushState');
+            spyOn(urlUtils, 'goToUrl');
         });
 
         it('should set `sort` query param to the value of selected option', () => {
             hooks.emit(eventName, event);
 
-            expect(History.pushState).toHaveBeenCalledWith({}, '', '/context.html?sort=featured');
+            expect(urlUtils.goToUrl).toHaveBeenCalledWith('/context.html?sort=featured');
         });
 
         it('should prevent default event', function() {
@@ -268,13 +261,13 @@ describe('FacetedSearch', () => {
                 preventDefault: jasmine.createSpy('preventDefault'),
             };
 
-            spyOn(History, 'pushState');
+            spyOn(urlUtils, 'goToUrl');
         });
 
         it('should change the URL of window to the URL of facet item', () => {
             hooks.emit(eventName, event);
 
-            expect(History.pushState).toHaveBeenCalledWith({}, '', '?brand=item1');
+            expect(urlUtils.goToUrl).toHaveBeenCalledWith('?brand=item1');
         });
 
         it('should prevent default event', function() {

--- a/assets/js/theme/common/faceted-search.js
+++ b/assets/js/theme/common/faceted-search.js
@@ -122,7 +122,7 @@ class FacetedSearch {
     updateView() {
         $(this.options.blockerSelector).show();
 
-        api.getPage(History.getState().url, this.requestOptions, (err, content) => {
+        api.getPage(urlUtils.getUrl(), this.requestOptions, (err, content) => {
             $(this.options.blockerSelector).hide();
 
             if (err) {
@@ -169,7 +169,7 @@ class FacetedSearch {
 
     getMoreFacetResults($navList) {
         const facet = $navList.data('facet');
-        const facetUrl = History.getState().url;
+        const facetUrl = urlUtils.getUrl();
 
         if (this.requestOptions.showMore) {
             api.getPage(facetUrl, {

--- a/assets/js/theme/common/url-utils.js
+++ b/assets/js/theme/common/url-utils.js
@@ -1,8 +1,12 @@
+import $ from 'jquery';
 import Url from 'url';
 
 const urlUtils = {
+    getUrl: () => `${window.location.pathname}${window.location.search}`,
+
     goToUrl: (url) => {
-        History.pushState({}, document.title, url);
+        window.history.pushState({}, document.title, url);
+        $(window).trigger('statechange');
     },
 
     replaceParams: (url, params) => {

--- a/assets/js/theme/global.js
+++ b/assets/js/theme/global.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import './common/select-option-plugin';
-import 'history.js/scripts/bundled-uncompressed/html4+html5/jquery.history';
+import 'html5-history-api';
 import PageManager from '../page-manager';
 import quickSearch from './global/quick-search';
 import currencySelector from './global/currency-selector';

--- a/assets/js/theme/product.js
+++ b/assets/js/theme/product.js
@@ -19,8 +19,8 @@ export default class Product extends PageManager {
     before(next) {
         // Listen for foundation modal close events to sanitize URL after review.
         $(document).on('close.fndtn.reveal', () => {
-            if (this.url.indexOf('#writeReview') !== -1) {
-                History.replaceState('', document.title, window.location.pathname);
+            if (this.url.indexOf('#writeReview') !== -1 && typeof window.history.replaceState === 'function') {
+                window.history.replaceState(null, document.title, window.location.pathname);
             }
         });
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "grunt-karma": "^0.12.2",
     "grunt-scss-lint": "^0.3.8",
     "grunt-svgstore": "^0.5.0",
-    "history.js": "browserstate/history.js",
+    "html5-history-api": "^4.2.7",
     "jasmine-core": "^2.2.0",
     "jquery": "^2.2.1",
     "jquery-zoom": "^1.7.15",

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -1,7 +1,7 @@
 var webpack = require('webpack');
 
 module.exports = {
-    devtool: 'eval-cheap-module-source-map',
+    devtool: 'source-map',
     bail: true,
     module: {
         loaders: [


### PR DESCRIPTION
# What?
MERC-1272: Use of URLs with a hashbang (#!) removes the hashbang from the URL and adds it back to window.location without the #

# How?
This PR replaces [history.js](https://github.com/browserstate/history.js/) which is abandoned and buggy with [HTML5-History-API](https://github.com/devote/HTML5-History-API) which operates according to W3C specification.

@lord2800 @sherrybc 