### PR TITLE
As low as

### DIFF
--- a/config.json
+++ b/config.json
@@ -234,7 +234,8 @@
     "optimizedCheckout-step-text": "#ffffff",
     "optimizedCheckout-form-text": "#666666",
     "optimizedCheckout-formField-backgroundColor": "white",
-    "optimizedCheckout-formField-borderColor": "#989898"
+    "optimizedCheckout-formField-borderColor": "#989898",
+    "price_as_low_as": false
   },
   "read_only_files": [
     "/assets/scss/components/citadel",

--- a/schema.json
+++ b/schema.json
@@ -2104,5 +2104,24 @@
         "id": "show_copyright_footer"
       }
     ]
+  },
+  {
+    "name": "Purchase Options",
+    "settings": [
+      {
+        "type": "paragraph",
+        "content": "Add 'As low as' pricing text to products with options on layout pages."
+      },
+      {
+        "type": "checkbox",
+        "label": "Add 'As low as' text",
+        "force_reload": true,
+        "id": "price_as_low_as"
+      },
+      {
+        "type": "paragraph",
+        "content": "*only recommended if default options are set to lowest price available for each product"
+      }
+    ]
   }
 ]

--- a/templates/components/products/price.html
+++ b/templates/components/products/price.html
@@ -1,37 +1,83 @@
-{{#if price.with_tax}}
-    <div class="price-section price-section--withTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
-        {{#if price.rrp_with_tax}}
-            <span data-product-rrp-with-tax class="price price--rrp">{{price.rrp_with_tax.formatted}}</span>
-        {{/if}}
-        <span data-product-price-with-tax class="price">{{price.with_tax.formatted}}</span>
-        {{#if price.without_tax}}
-            {{lang 'products.price_with_tax' tax_label=price.tax_label}}
-        {{/if}}
-    </div>
-{{/if}}
-
-{{#if price.without_tax}}
-    <div class="price-section price-section--withoutTax {{#if price.with_tax}}price-section--minor{{/if}}"  {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
-        {{#if price.rrp_without_tax}}
-            <span data-product-rrp-without-tax class="price price--rrp">{{price.rrp_without_tax.formatted}}</span>
-        {{/if}}
-        {{#if schema_org}}
-            <meta itemprop="price" content="{{price.without_tax.value}}">
-            <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
-        {{/if}}
-        <span data-product-price-without-tax class="price price--withoutTax">{{price.without_tax.formatted}}</span>
-        {{#if price.with_tax}}
-            <abbr title="{{lang 'products.excluding_tax'}}">{{lang 'products.price_without_tax' tax_label=price.tax_label}}</abbr>
-        {{/if}}
-    </div>
-{{/if}}
-
-{{#if page_type '===' 'product'}}
-    {{#if price.saved}}
-        <div class="price-section price-section--saving">
-            <span class="price">
-                {{lang 'products.you_save' amount=price.saved.formatted}}
-            </span>
+{{#or has_options product.options.length}}
+    {{#if price.with_tax}}
+        <div class="price-section price-section--withTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
+            {{#if price.rrp_with_tax}}
+                <span data-product-rrp-with-tax class="price price--rrp">{{price.rrp_with_tax.formatted}}</span>
+            {{/if}}
+            {{#if page_type '!==' 'product'}}
+                {{#if theme_settings.price_as_low_as}}
+                    <span translate>As low as </span>
+                {{/if}}
+            {{/if}}
+            <span data-product-price-with-tax class="price">{{price.with_tax.formatted}}</span>
+            {{#if price.without_tax}}
+                {{lang 'products.price_with_tax' tax_label=price.tax_label}}
+            {{/if}}
         </div>
     {{/if}}
-{{/if}}
+    {{#if price.without_tax}}
+        <div class="price-section price-section--withoutTax {{#if price.with_tax}}price-section--minor{{/if}}"  {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
+            {{#if price.rrp_without_tax}}
+                <span data-product-rrp-without-tax class="price price--rrp">{{price.rrp_without_tax.formatted}}</span>
+            {{/if}}
+            {{#if schema_org}}
+                <meta itemprop="price" content="{{price.without_tax.value}}">
+                <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
+            {{/if}}
+            {{#if page_type '!==' 'product'}}
+                {{#if theme_settings.price_as_low_as}}
+                    <span translate>As low as </span>
+                {{/if}}
+            {{/if}}
+            <span data-product-price-without-tax class="price price--withoutTax">{{price.without_tax.formatted}}</span>
+            {{#if price.with_tax}}
+                <abbr title="{{lang 'products.excluding_tax'}}">{{lang 'products.price_without_tax' tax_label=price.tax_label}}</abbr>
+            {{/if}}
+        </div>
+    {{/if}}
+    {{#if page_type '===' 'product'}}
+        {{#if price.saved}}
+            <div class="price-section price-section--saving">
+                <span class="price">
+                    {{lang 'products.you_save' amount=price.saved.formatted}}
+                </span>
+            </div>
+        {{/if}}
+    {{/if}}
+{{else}}
+    {{#if price.with_tax}}
+        <div class="price-section price-section--withTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
+            {{#if price.rrp_with_tax}}
+                <span data-product-rrp-with-tax class="price price--rrp">{{price.rrp_with_tax.formatted}}</span>
+            {{/if}}
+            <span data-product-price-with-tax class="price">{{price.with_tax.formatted}}</span>
+            {{#if price.without_tax}}
+                {{lang 'products.price_with_tax' tax_label=price.tax_label}}
+            {{/if}}
+        </div>
+    {{/if}}
+    {{#if price.without_tax}}
+        <div class="price-section price-section--withoutTax {{#if price.with_tax}}price-section--minor{{/if}}"  {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
+            {{#if price.rrp_without_tax}}
+                <span data-product-rrp-without-tax class="price price--rrp">{{price.rrp_without_tax.formatted}}</span>
+            {{/if}}
+            {{#if schema_org}}
+                <meta itemprop="price" content="{{price.without_tax.value}}">
+                <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
+            {{/if}}
+            <span data-product-price-without-tax class="price price--withoutTax">{{price.without_tax.formatted}}</span>
+            {{#if price.with_tax}}
+                <abbr title="{{lang 'products.excluding_tax'}}">{{lang 'products.price_without_tax' tax_label=price.tax_label}}</abbr>
+            {{/if}}
+        </div>
+    {{/if}}
+    {{#if page_type '===' 'product'}}
+        {{#if price.saved}}
+            <div class="price-section price-section--saving">
+                <span class="price">
+                    {{lang 'products.you_save' amount=price.saved.formatted}}
+                </span>
+            </div>
+        {{/if}}
+    {{/if}}
+{{/or}}


### PR DESCRIPTION
* replaces https://github.com/bigcommerce/stencil/pull/858

* shows 'As low as' label on the non-product pages when the `price_as_low_as` flag is set to `true`; defaults to `false` for *all* Cornerstone themes.  flag is set with toggle in Theme Editor.

![toggle](https://cloud.githubusercontent.com/assets/1357197/20855470/1bf4e778-b8b2-11e6-8b63-1f1dcafb7478.png)

`price_as_low_as = false`

![off](https://cloud.githubusercontent.com/assets/1357197/20855445/e5ce64bc-b8b1-11e6-9f89-a17312a28889.png)

`price_as_low_as = true`

![on](https://cloud.githubusercontent.com/assets/1357197/20855464/0b0a0e98-b8b2-11e6-8cf1-059ae0d170fe.png)
