### PR TITLE
social media placement

### DIFF
--- a/assets/scss/components/citadel/forms/_forms.scss
+++ b/assets/scss/components/citadel/forms/_forms.scss
@@ -206,7 +206,7 @@
     }
 
     .button {
-        @include breakpoint("medium") {
+        @include breakpoint("large") {
             width: auto;
         }
     }

--- a/assets/scss/components/stencil/navUser/_navUser.scss
+++ b/assets/scss/components/stencil/navUser/_navUser.scss
@@ -120,6 +120,17 @@
 
     @include breakpoint("medium") {
         display: block;
+
+        &.navUser-item--social {
+            margin-top: rem-calc(5px);
+            padding-right: rem-calc(5px);
+        }
+
+        &.navUser-item--divider {
+            font-size: rem-calc(25px);
+            margin-top: rem-calc(8px);
+            padding-left: rem-calc(2px);
+        }
     }
 }
 

--- a/assets/scss/components/stencil/socialLinks/_socialLinks.scss
+++ b/assets/scss/components/stencil/socialLinks/_socialLinks.scss
@@ -9,6 +9,7 @@
 .socialLinks {
     @include clearfix;
     @include u-listReset; // 2
+    line-height: lineHeight("largest");
 
     .icon { // 1
         @include square($socialLinks-iconSize);

--- a/assets/scss/layouts/footer/_footer.scss
+++ b/assets/scss/layouts/footer/_footer.scss
@@ -52,9 +52,31 @@
 }
 
 .footer-info-col--small {
-
     @include breakpoint("medium") {
         width: width("2/12");
+    }
+}
+
+.footer-info-col--social {
+    width: 100%;
+}
+
+.footer-info-col--left {
+    @include breakpoint("small") {
+        padding: 0;
+    }
+}
+
+.footer-info-col--right {
+    @include breakpoint("small") {
+        left: 50%;
+        position: inherit;
+    }
+
+    @include breakpoint("medium") {
+        left: 0;
+        padding: 0;
+        text-align: right;
     }
 }
 

--- a/assets/scss/settings/stencil/socialLinks/_settings.scss
+++ b/assets/scss/settings/stencil/socialLinks/_settings.scss
@@ -4,5 +4,5 @@
 
 $socialLinks-iconSize:                  20px;
 
-$socialLinks-alt-iconSize:              28px;
+$socialLinks-alt-iconSize:              21px;
 $socialLinks-alt-iconColor:             stencilColor("color-textSecondary");

--- a/config.json
+++ b/config.json
@@ -242,7 +242,9 @@
     "color_text_product_sale_badges": "#ffffff",
     "color_hover_product_sale_badges": "#000000",
     "restrict_to_login": false,
-    "swatch_option_size": "22x22"
+    "swatch_option_size": "22x22",
+    "social_icon_placement_top": false,
+    "social_icon_placement_bottom": "bottom_right"
   },
   "read_only_files": [
     "/assets/scss/components/citadel",

--- a/schema.json
+++ b/schema.json
@@ -822,6 +822,41 @@
     ]
   },
   {
+    "name": "Social Media Icons",
+    "settings": [
+      {
+        "type": "heading",
+        "content": "Placement"
+      },   
+      {
+        "type": "checkbox",
+        "label": "Top Right (Toggle On/Off)",
+        "force_reload": true,  
+        "id": "social_icon_placement_top"
+      },
+      {
+        "type": "select",
+        "label": "Bottom Placement",
+        "id": "social_icon_placement_bottom",
+        "force_reload": true,
+        "options": [
+          {
+            "value": "bottom_none",
+            "label": "None"
+          },
+          {
+            "value": "bottom_right",
+            "label": "Right"
+          },
+          {
+            "value": "bottom_left",
+            "label": "Left"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "name": "Products",
     "settings": [
       {

--- a/templates/components/common/footer.html
+++ b/templates/components/common/footer.html
@@ -7,14 +7,23 @@
 {{/if}}
 <footer class="footer" role="contentinfo">
     <div class="container">
+        {{#if theme_settings.social_icon_placement_bottom '!==' 'bottom_none'}}
+            <article class="footer-info-col
+                footer-info-col--social
+                footer-info-col--{{#if theme_settings.social_icon_placement_bottom '===' 'bottom_left'}}left{{else}}right{{/if}}"
+                data-section-type="footer-webPages">
+                    <h5 class="footer-info-heading">{{lang 'social.connect'}}</h5>
+                    {{> components/common/social-links}}
+            </article>
+        {{/if}}
         <section class="footer-info">
             <article class="footer-info-col footer-info-col--small" data-section-type="footer-webPages">
                 <h5 class="footer-info-heading">{{lang 'footer.navigate'}}</h5>
                 <ul class="footer-info-list">
                     {{#each pages}}
-                    <li>
-                        <a href="{{url}}">{{name}}</a>
-                    </li>
+                        <li>
+                            <a href="{{url}}">{{name}}</a>
+                        </li>
                     {{/each}}
                     <li>
                         <a href="{{urls.sitemap}}">{{lang 'sitemap.page_title'}}</a>
@@ -59,7 +68,6 @@
                 {{#if settings.show_newsletter_box}}
                     {{> components/common/subscription-form}}
                 {{/if}}
-                {{> components/common/social-links}}
                 {{> components/common/payment-icons}}
             </article>
         </section>

--- a/templates/components/common/navigation-menu.html
+++ b/templates/components/common/navigation-menu.html
@@ -95,5 +95,10 @@
                 <a class="navPages-action" href="{{urls.auth.login}}">{{lang 'common.login'}}</a> {{lang 'common.or'}} <a class="navPages-action" href="{{urls.auth.create_account}}">{{lang 'common.sign_up'}}</a>
             </li>
         {{/if}}
+        {{#if theme_settings.social_icon_placement_top}}
+            <li class="navPages-item">
+                {{> components/common/social-links}}
+            </li>
+        {{/if}}
     </ul>
 </nav>

--- a/templates/components/common/navigation.html
+++ b/templates/components/common/navigation.html
@@ -18,6 +18,12 @@
         <li class="navUser-item">
             <a class="navUser-action navUser-item--compare" href="{{urls.compare}}" data-compare-nav>{{lang 'common.compare'}} <span class="countPill countPill--positive countPill--alt"></span></a>
         </li>
+        {{#if theme_settings.social_icon_placement_top}}
+            <li class="navUser-item navUser-item--social">
+                {{> components/common/social-links}}
+            </li>
+            <li class="navUser-item navUser-item--divider">|</li>
+        {{/if}}
         <li class="navUser-item">
             <a class="navUser-action navUser-action--quickSearch" href="#" data-search="quickSearch" aria-controls="quickSearch" aria-expanded="false">{{lang 'common.search'}}</a>
         </li>

--- a/templates/components/common/payment-icons.html
+++ b/templates/components/common/payment-icons.html
@@ -1,17 +1,21 @@
-<div class="footer-payment-icons">
-    {{#if theme_settings.show_accept_amex}}
-        <svg class="footer-payment-icon"><use xlink:href="#icon-logo-american-express"></use></svg>
-    {{/if}}
-    {{#if theme_settings.show_accept_discover}}
-        <svg class="footer-payment-icon"><use xlink:href="#icon-logo-discover"></use></svg>
-    {{/if}}
-    {{#if theme_settings.show_accept_mastercard}}
-        <svg class="footer-payment-icon"><use xlink:href="#icon-logo-mastercard"></use></svg>
-    {{/if}}
-    {{#if theme_settings.show_accept_paypal}}
-        <svg class="footer-payment-icon"><use xlink:href="#icon-logo-paypal"></use></svg>
-    {{/if}}
-    {{#if theme_settings.show_accept_visa}}
-        <svg class="footer-payment-icon"><use xlink:href="#icon-logo-visa"></use></svg>
-    {{/if}}
-</div>
+{{#with theme_settings}}
+    {{#or show_accept_amex show_accept_discover show_accept_mastercard show_accept_paypal show_accept_visa}}
+        <div class="footer-payment-icons">
+            {{#if show_accept_amex}}
+                <svg class="footer-payment-icon"><use xlink:href="#icon-logo-american-express"></use></svg>
+            {{/if}}
+            {{#if show_accept_discover}}
+                <svg class="footer-payment-icon"><use xlink:href="#icon-logo-discover"></use></svg>
+            {{/if}}
+            {{#if show_accept_mastercard}}
+                <svg class="footer-payment-icon"><use xlink:href="#icon-logo-mastercard"></use></svg>
+            {{/if}}
+            {{#if show_accept_paypal}}
+                <svg class="footer-payment-icon"><use xlink:href="#icon-logo-paypal"></use></svg>
+            {{/if}}
+            {{#if show_accept_visa}}
+                <svg class="footer-payment-icon"><use xlink:href="#icon-logo-visa"></use></svg>
+            {{/if}}
+        </div>
+    {{/or}}
+{{/with}}

--- a/templates/components/common/social-links.html
+++ b/templates/components/common/social-links.html
@@ -1,5 +1,4 @@
 {{#if social_media}}
-    <h5 class="footer-info-heading">{{lang 'social.connect'}}</h5>
     <ul class="socialLinks socialLinks--alt">
         {{#each social_media}}
             <li class="socialLinks-item">


### PR DESCRIPTION
## settings are configured in Theme Editor or `config.json`

Theme Editor settings:
![settings](https://cloud.githubusercontent.com/assets/1357197/20939811/362d38ca-bba5-11e6-9b26-9068e09d1a8b.png)

`social_icon_placement_top = false`:
![top_off](https://cloud.githubusercontent.com/assets/1357197/20939821/3fb3db9c-bba5-11e6-8318-58ae03c79ff6.png)

`social_icon_placement_top = true`:
![top_on](https://cloud.githubusercontent.com/assets/1357197/20939822/3fcb0588-bba5-11e6-80ec-bd02b8f709ae.png)

`theme_settings.social_icon_placement_bottom = 'bottom_none'`:
![bottom_none](https://cloud.githubusercontent.com/assets/1357197/20939819/3fb313ec-bba5-11e6-90ff-687d9cd95e9c.png)

`theme_settings.social_icon_placement_bottom = 'bottom_left'`:
![bottom_left](https://cloud.githubusercontent.com/assets/1357197/20939820/3fb3592e-bba5-11e6-9a30-ebcd4eb5218f.png)

`theme_settings.social_icon_placement_bottom = 'bottom_right'`:
![bottom_right](https://cloud.githubusercontent.com/assets/1357197/20939818/3fb309d8-bba5-11e6-9ce7-da8336ba5163.png)

## moves Social Media Icons to top-level, replacing Layout Settings
* "Hide Content Pages in Main Menu" and "Show Quickview" are moved out of Layout Settings in #897
* updates Social Media Icons heading to be 'Placement'
![screen shot 2016-12-15 at 1 21 35 pm](https://cloud.githubusercontent.com/assets/1357197/21246551/5a9a07de-c2de-11e6-92dd-771d046c6546.png)

