### PR TITLE
swatch changes

### DIFF
--- a/assets/scss/layouts/_layouts.scss
+++ b/assets/scss/layouts/_layouts.scss
@@ -43,5 +43,8 @@
 // Product Sale Badges
 @import "products/productSaleBadges";
 
+// Product view
+@import "products/productSwatch";
+
 // Account
 @import "account/account";

--- a/assets/scss/layouts/products/_productSwatch.scss
+++ b/assets/scss/layouts/products/_productSwatch.scss
@@ -1,0 +1,20 @@
+// =============================================================================
+// SWATCH SIZES (CSS)
+// =============================================================================
+
+
+// Swatch Size Changes
+// -----------------------------------------------------------------------------
+
+// do some math
+
+$value_of_swatch_size : stencilString("swatch_option_size");
+$position_of_x : str-index($value_of_swatch_size, "x");
+$first_value : str-slice($value_of_swatch_size, 0, $position_of_x - 1);
+$second_value : str-slice($value_of_swatch_size, $position_of_x + 1);
+
+.form-option-variant--color,
+.form-option-variant--pattern {
+    height: $first_value +"px";
+    width: $second_value +"px";
+}

--- a/config.json
+++ b/config.json
@@ -241,7 +241,8 @@
     "color_badge_product_sale_badges": "#007dc6",
     "color_text_product_sale_badges": "#ffffff",
     "color_hover_product_sale_badges": "#000000",
-    "restrict_to_login": false
+    "restrict_to_login": false,
+    "swatch_option_size": "22x22"
   },
   "read_only_files": [
     "/assets/scss/components/citadel",

--- a/schema.json
+++ b/schema.json
@@ -1199,6 +1199,26 @@
         ]
       },
       {
+        "label": "Product Swatch Image Sizes",
+        "type": "imageDimension",
+        "id": "swatch_option_size",
+        "force_reload": true, 
+        "options": [
+          {
+            "value": "22x22",
+            "label": "Standard"
+          },
+          {
+            "value": "custom",
+            "label": "Specify dimensions"
+         }        
+        ]
+      },
+      {
+        "type": "paragraph",
+        "content": "*For texture swatches, max dimensions are 150x150."
+      },
+      {
         "type": "heading",
         "content": "Category pages"
       },

--- a/templates/components/products/options/swatch.html
+++ b/templates/components/products/options/swatch.html
@@ -12,7 +12,7 @@
         <input class="form-radio" type="radio" name="attribute[{{../id}}]" value="{{id}}" id="attribute_{{id}}" {{#if selected}}checked{{/if}} {{#if ../required}}required{{/if}}>
         <label class="form-option" for="attribute_{{id}}" data-product-attribute-value="{{id}}">
             {{#if image}}
-                <span class='form-option-variant form-option-variant--pattern' title="{{this.label}}" style="background-image: url('{{getImage image "thumb_size"}}');"></span>
+                <span class='form-option-variant form-option-variant--pattern' title="{{this.label}}" style="background-image: url('{{getImage image "swatch_option_size"}}');"></span>
             {{/if}}
             {{#if data.[2]}}
                 <span class='form-option-variant form-option-variant--color' title="{{this.label}}" style="background-color: #{{data.[0]}}"></span>


### PR DESCRIPTION
## provides the ability to adjust the swatch size
(re-introduces the reverted merge from #855)

uncomment the needed scss
fixing errors from travis-ci
updated for errors from testing
changed swatches to have warning that swatches max at 150x150

e.g.:

![screen shot 2016-12-12 at 12 44 14 pm](https://cloud.githubusercontent.com/assets/1357197/21116049/ca066234-c068-11e6-825e-ba0e124da391.png)
