### PR TITLE
spraypaint ux adjustments

### DIFF
--- a/config.json
+++ b/config.json
@@ -54,7 +54,7 @@
     "searchpage_products_per_page": 12,
     "show_product_quick_view": true,
     "show_powered_by": true,
-    "shop_by_brand_hide_footer": true,
+    "shop_by_brand_show_footer": false,
     "show_copyright_footer": true,
     "show_accept_amex": false,
     "show_accept_discover": false,

--- a/schema.json
+++ b/schema.json
@@ -68,23 +68,6 @@
     ]
   },
   {
-    "name": "Layout Settings",
-    "settings": [
-      {
-        "type": "checkbox",
-        "label": "Show Quickview",
-        "force_reload": true,
-        "id": "show_product_quick_view"
-      },
-      {
-        "type": "checkbox",
-        "label": "Hide Content Pages in Main Menu",
-        "force_reload": true,
-        "id": "hide_content_navigation"
-      }
-    ]
-  },
-  {
     "name": "Typography & Icons",
     "settings": [
       {
@@ -676,6 +659,12 @@
         "content": "Page navigation"
       },
       {
+        "type": "checkbox",
+        "label": "Hide Content Pages in Main Menu",
+        "force_reload": true,
+        "id": "hide_content_navigation"
+      },
+      {
         "type": "color",
         "label": "Text color",
         "id": "navPages-color"
@@ -835,6 +824,12 @@
   {
     "name": "Products",
     "settings": [
+      {
+        "type": "checkbox",
+        "label": "Show Quickview",
+        "force_reload": true,
+        "id": "show_product_quick_view"
+      },
       {
         "type": "heading",
         "content": "Home page"
@@ -2093,19 +2088,19 @@
       },
       {
         "type": "checkbox",
-        "label": "Show Powered By",
+        "label": "Show &quot;Powered by BigCommerce&quot;",
         "force_reload": true,
         "id": "show_powered_by"
       },
       {  
         "type": "checkbox",
-        "label": "Hide Brands in Footer",
+        "label": "Show brands in footer",
         "force_reload": true,  
-        "id": "shop_by_brand_hide_footer"
+        "id": "shop_by_brand_show_footer"
       },
       {
         "type": "checkbox",
-        "label": "Show Copyright Info",
+        "label": "Show &quot;&copy;&quot;, current year and store name",
         "force_reload": true,
         "id": "show_copyright_footer"
       }

--- a/templates/components/common/footer.html
+++ b/templates/components/common/footer.html
@@ -33,7 +33,7 @@
                 </ul>
             </article>
 
-            {{#unless theme_settings.shop_by_brand_hide_footer}}
+            {{#if theme_settings.shop_by_brand_show_footer}}
             <article class="footer-info-col footer-info-col--small" data-section-type="footer-brands">
                 <h5 class="footer-info-heading">{{lang 'footer.brands'}}</h5>
                 <ul class="footer-info-list">
@@ -45,7 +45,7 @@
                     <li><a href="{{urls.brands}}">{{lang 'common.view_all'}}</a></li>
                 </ul>
             </article>
-            {{/unless}}
+            {{/if}}
 
             <article class="footer-info-col footer-info-col--small" data-section-type="storeInfo">
                 <h5 class="footer-info-heading">{{lang 'footer.info'}}</h5>


### PR DESCRIPTION
1. Moves the "Quickview" setting from the "Layout Settings" accordion to the Products accordion
![screen shot 2016-12-15 at 1 09 35 pm](https://cloud.githubusercontent.com/assets/1357197/21242130/afde42c6-c2c7-11e6-8b95-8c4d59d816f8.png)

2. Moves the "Content pages in Main Menu" setting from the "Layout Settings" accordion to the "Header > Page Navigation" accordion
![screen shot 2016-12-15 at 1 10 13 pm](https://cloud.githubusercontent.com/assets/1357197/21242148/c59c1732-c2c7-11e6-962f-0ee56a1ea2cd.png)

3. In the Footer > Show Copyright section – adds more qualification:  Show "©", current year and store name
4. In the Footer > Show Powered By – adds more qualification: "Powered by BigCommerce"
5. In the Footer > Hide Brands in Footer has been changed to "Show brands in footer".
![screen shot 2016-12-15 at 3 55 14 pm](https://cloud.githubusercontent.com/assets/1357197/21246658/e13b9d0c-c2de-11e6-83e5-557f77202872.png)
