### PR TITLE
MERC-1619

### DIFF
--- a/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
+++ b/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
@@ -15,7 +15,11 @@
 
 .heroCarousel {
     margin-bottom: (spacing("double") + spacing("single"));
-    margin-top: -(spacing("single") + spacing("base"));
+    margin-top: -(spacing("single"));
+
+    @include breakpoint("medium") {
+        margin-top: -(spacing("single") + spacing("base"));
+    }
 
     .js & { // 2
         max-height: remCalc(0);

--- a/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
+++ b/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
@@ -18,6 +18,9 @@
     margin-top: -(spacing("single"));
 
     @include breakpoint("medium") {
+        // Added to visually override the top margin for _body.scss on mobile.
+        // The '.body' top margin creates space between the header and page content.
+        // However, on the homepage, we want the carousel flush with the header.
         margin-top: -(spacing("single") + spacing("base"));
     }
 

--- a/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
+++ b/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
@@ -2,26 +2,27 @@
 // -----------------------------------------------------------------------------
 //
 // Purpose: Styles the hero carousel component, which basically adds extras to the
-// vendor slick carousel, to specifically display hero images
+// vendor slick carousel, to specifically display hero images.
 //
 // 1. Hide the actual image element to allow background-size: cover treatment on
 //    large screens to scale image. Use visibility because the JS uses the height
-//    to set the slide size
+//    to set the slide size.
 //
 // 2. With JS on, minimise the jump in content as you progressively enhance the
 //    slider. Slowly fade and slide the height, instead of a jump in collapsing
 //    hidden content.
+//
+// 3. Visually overrides the top margin for '.body' defined in _body.scss.
+//    The '.body' top margin creates space between the header and page content.
+//    However, on the homepage, we want the carousel to be flush with the header.
 // -----------------------------------------------------------------------------
 
 .heroCarousel {
     margin-bottom: (spacing("double") + spacing("single"));
-    margin-top: -(spacing("single"));
+    margin-top: -(spacing("single")); // 3
 
     @include breakpoint("medium") {
-        // Added to visually override the top margin for _body.scss on mobile.
-        // The '.body' top margin creates space between the header and page content.
-        // However, on the homepage, we want the carousel flush with the header.
-        margin-top: -(spacing("single") + spacing("base"));
+        margin-top: -(spacing("single") + spacing("base")); // 3
     }
 
     .js & { // 2

--- a/assets/scss/layouts/body/_body.scss
+++ b/assets/scss/layouts/body/_body.scss
@@ -12,6 +12,7 @@
     margin-top: spacing("single"); // 1
 
     @include breakpoint("medium") {
+        //If you change the spacing here, please update the heroCarousel too.
         margin-top: spacing("single") + spacing("base"); // 1
     }
 }

--- a/assets/scss/layouts/body/_body.scss
+++ b/assets/scss/layouts/body/_body.scss
@@ -2,7 +2,8 @@
 // BODY (CSS)
 //
 // 1. Header is fixed on small screens, use the content body to create the whitespace
-// between it and the header on all situations
+//    between it and the header on all situations. If you change the spacing here,
+//    please update .heroCarousel too.
 //
 // =============================================================================
 
@@ -12,7 +13,6 @@
     margin-top: spacing("single"); // 1
 
     @include breakpoint("medium") {
-        //If you change the spacing here, please update the heroCarousel too.
         margin-top: spacing("single") + spacing("base"); // 1
     }
 }


### PR DESCRIPTION
MERC-1619: Adding a margin top to the carousel on mobile view. This is to prevent the carousel's images from being cutoff near the top on mobile devices. Here's a screenshot of before (left) and after (right):

![before-after-merc-1619](https://cloud.githubusercontent.com/assets/8430791/21626638/d7301e20-d1d7-11e6-9d6b-34f8f725f8a8.png)

**Why**
Hi Cristy Carpenter and Pascal Zajac, I cannot remember anything . But looking at the code, I think a positive margin of 2.5rem is added to `.body`. in order to visually override the negative 2.5rem margin added to `.heroCarousel`. We need to do to this because we want a gap between the header and the body for content pages. But for the homepage, we want the carousel to sit flush against the header.
It looks like when Chris adjusted the body margin to 1.5rem for mobile, he forgot to also reduce it in `.heroCarousel`. So, instead of removing breakpoint adjustment in `_body.scss`, I think the proper fix is to change `_heroCarousel.scss` to have `margin-top` like the following:

```
.heroCarousel {
    margin-top: -spacing("single");
 
    @include breakpoint("medium") {
        margin-top: -(spacing("single") + spacing("base"));
    }
}
```
