### PR TITLE
STENCIL-2455: Prevents carousel images from being cut off on large sc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Draft
+- Added a setting to theme editor schema to show/hide the homepage carousel [#909](https://github.com/bigcommerce/stencil/pull/909)
+- Prevent carousel images from being cut off on large screens by adding a new setting to theme editor schema [#909](https://github.com/bigcommerce/stencil/pull/909)
+
 ## 1.5.1 (2017-02-07)
 - Fix an issue with a horizontal scroll bar showing in theme editor [#915](https://github.com/bigcommerce/stencil/pull/915)
 - Hide Gift Certificates when the setting is disabled in the control panel [#914](https://github.com/bigcommerce/stencil/pull/914) & [#916](https://github.com/bigcommerce/stencil/pull/916)

--- a/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
+++ b/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
@@ -78,17 +78,19 @@
         }
     }
 
+    &.heroCarousel-slide-stretch .heroCarousel-slide {
+        @include breakpoint("large") { // 4
+            background-size: 100% 100%;
+        }
+    }
 }
+
 
 .heroCarousel-slide {
     background-position: 50%;
     background-repeat: no-repeat;
     background-size: cover;
     position: relative;
-
-    @include breakpoint("large") { // 4
-        background-size: 100% 100%;
-    }
 
     a {
         text-decoration: none;

--- a/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
+++ b/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
@@ -15,6 +15,9 @@
 // 3. Visually overrides the top margin for '.body' defined in _body.scss.
 //    The '.body' top margin creates space between the header and page content.
 //    However, on the homepage, we want the carousel to be flush with the header.
+//
+// 4. Allows image to scale on large screens while preventing the top and bottom
+//    from becoming cut off.
 // -----------------------------------------------------------------------------
 
 .heroCarousel {
@@ -82,6 +85,10 @@
     background-repeat: no-repeat;
     background-size: cover;
     position: relative;
+
+    @include breakpoint("large") { // 4
+        background-size: 100% 100%;
+    }
 
     a {
         text-decoration: none;

--- a/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
+++ b/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
@@ -77,14 +77,7 @@
             @include carouselOpaqueBackgrounds($slick-dot-bgColor);
         }
     }
-
-    &.heroCarousel-slide-stretch .heroCarousel-slide {
-        @include breakpoint("large") { // 4
-            background-size: 100% 100%;
-        }
-    }
 }
-
 
 .heroCarousel-slide {
     background-position: 50%;
@@ -94,6 +87,12 @@
 
     a {
         text-decoration: none;
+    }
+}
+
+.heroCarousel-slide--stretch {
+    @include breakpoint("large") { // 4
+        background-size: 100% 100%;
     }
 }
 

--- a/config.json
+++ b/config.json
@@ -41,6 +41,7 @@
     "homepage_featured_products_count": 8,
     "homepage_top_products_count": 8,
     "homepage_show_carousel": true,
+    "homepage_stretch_carousel_images": false,
     "homepage_new_products_column_count": 4,
     "homepage_featured_products_column_count": 4,
     "homepage_top_products_column_count": 4,

--- a/schema.json
+++ b/schema.json
@@ -745,6 +745,18 @@
     "name": "Carousel",
     "settings": [
       {
+        "type": "checkbox",
+        "label": "Show Carousel",
+        "force_reload": true,
+        "id": "homepage_show_carousel"
+      },
+      {
+        "type": "checkbox",
+        "label": "Allows image to stretch on large screens",
+        "force_reload": true,
+        "id": "homepage_stretch_carousel_images"
+      },
+      {
         "type": "color",
         "label": "Background color",
         "id": "carousel-bgColor"
@@ -827,11 +839,11 @@
       {
         "type": "heading",
         "content": "Placement"
-      },   
+      },
       {
         "type": "checkbox",
         "label": "Top Right (Toggle On/Off)",
-        "force_reload": true,  
+        "force_reload": true,
         "id": "social_icon_placement_top"
       },
       {
@@ -1237,7 +1249,7 @@
         "label": "Product Swatch Image Sizes",
         "type": "imageDimension",
         "id": "swatch_option_size",
-        "force_reload": true, 
+        "force_reload": true,
         "options": [
           {
             "value": "22x22",
@@ -1246,7 +1258,7 @@
           {
             "value": "custom",
             "label": "Specify dimensions"
-         }        
+         }
         ]
       },
       {
@@ -2190,10 +2202,10 @@
         "force_reload": true,
         "id": "show_powered_by"
       },
-      {  
+      {
         "type": "checkbox",
         "label": "Show brands in footer",
-        "force_reload": true,  
+        "force_reload": true,
         "id": "shop_by_brand_show_footer"
       },
       {

--- a/templates/components/carousel.html
+++ b/templates/components/carousel.html
@@ -1,4 +1,4 @@
-<section class="heroCarousel"
+<section class="heroCarousel {{#if theme_settings.homepage_stretch_carousel_images}}heroCarousel-slide-stretch{{/if}}"
     data-slick='{
         "dots": true,
         "mobileFirst": true,

--- a/templates/components/carousel.html
+++ b/templates/components/carousel.html
@@ -1,4 +1,4 @@
-<section class="heroCarousel {{#if theme_settings.homepage_stretch_carousel_images}}heroCarousel-slide-stretch{{/if}}"
+<section class="heroCarousel"
     data-slick='{
         "dots": true,
         "mobileFirst": true,
@@ -6,10 +6,10 @@
         "slidesToScroll": 1,
         "autoplay": true,
         "autoplaySpeed": {{carousel.swap_frequency}}
-    }'
->
+    }'>
     {{#each carousel.slides}}
-    <div class="heroCarousel-slide" style="background-image: url({{image}})">
+    <div class="heroCarousel-slide {{#if ../theme_settings.homepage_stretch_carousel_images}}heroCarousel-slide--stretch{{/if}}"
+        style="background-image: url({{image}})">
         <a href="{{url}}">
             <img class="heroCarousel-image" src="{{image}}" alt="{{alt_text}}" title="{{alt_text}}"/>
             {{#if heading}}


### PR DESCRIPTION
…reens.

**JIRA Ticket** 
https://jira.bigcommerce.com/browse/STENCIL-2455

**What**
Switches carousel background-size from "cover" to "100% 100%" which fits the entire image into the slide's viewing area. 

**Why**
Carousel images are currently becoming cut off on the top and bottom at browser widths greater than 1261px.

**Caveats**
Images may look a bit stretched. 
- We could increase the height set by the hero carousel? 
- We could remove "visibility: hidden" on .heroCarousel-image (although, the image wouldn't scale :/)

**Screenshots**
Before Change:
![stencil-2455-broken](https://cloud.githubusercontent.com/assets/8430791/22256855/ae99ce0c-e221-11e6-9000-2ceef762a785.png)

After Change:
![stencil-2455-fix](https://cloud.githubusercontent.com/assets/8430791/22256906/c727c6a4-e221-11e6-969d-c67bb4823c11.png)