### PR TITLE
CHECKOUT-1234: Expose translations object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Expose `language` object on the checkout page [#910](https://github.com/bigcommerce/stencil/pull/910)
 
 ## 1.5.3 (2017-02-23)
 - Show 'Write a Review' link for mobile [#922] (https://github.com/bigcommerce/stencil/pull/922)

--- a/templates/pages/checkout.html
+++ b/templates/pages/checkout.html
@@ -4,6 +4,10 @@
 {{{ stylesheet '/assets/css/optimized-checkout.css' }}}
 {{ getFontsCollection }}
 
+<script type="text/javascript">
+    window.language = {{{langJson 'optimized_checkout'}}};
+</script>
+
 {{/partial}}
 
 {{#partial "page"}}
@@ -27,4 +31,3 @@
 {{/partial}}
 
 {{> layout/empty}}
-


### PR DESCRIPTION
## What?
Expose a translation object on the checkout page.

Please note that this PR can only be merged after merging and releasing https://github.com/bigcommerce/paper/pull/103.

## Why?
So it can be used by UCO to display non-English strings.

## Testing / Proof
![uco-translation](https://cloud.githubusercontent.com/assets/667603/22277969/efbdb8ce-e313-11e6-97af-5dc537496d6a.gif)

@bigcommerce/checkout @mcampa @lord2800 