### PR TITLE
CRO-11: Fix scrollbar issue in viewport < md

### DIFF
--- a/assets/scss/components/vendor/slick/_slick.scss
+++ b/assets/scss/components/vendor/slick/_slick.scss
@@ -43,7 +43,7 @@
 }
 
 .slick-next {
-    right: -15px;
+    right: -10px;
 
     @include breakpoint("large") {
         right: -(spacing("double") + spacing("quarter"));


### PR DESCRIPTION
Ticket: [CRO-11: Horizontal bar in Stencil Theme Editor shouldn't be there](https://jira.bigcommerce.com/browse/CRO-11)

## Why?
In viewports less than md (smaller tablet, etc) an annoying horizontal scrollbar shows. Here's how it looks:
#### BEFORE:
![](http://g.recordit.co/yguPDFbDEm.gif)

## What?
The issue was from the right slick arrow for the carousel. It's pushed too far to the right by 5 pixels. Bringing it back 5 pixels solves the issue.
#### AFTER:
![](http://g.recordit.co/2PzLuFZoUN.gif)

## How was this tested
On multiple viewports, multiple browsers. All looks fine to me.