### PR TITLE
STENCIL-2446 Add check to show gift cert on mobile menu

### DIFF
--- a/templates/components/common/navigation-menu.html
+++ b/templates/components/common/navigation-menu.html
@@ -39,9 +39,11 @@
                 </div>
             </li>
         {{/if}}
-        <li class="navPages-item">
-            <a class="navPages-action" href="{{urls.gift_certificate.purchase}}">{{lang 'common.gift_cert'}}</a>
-        </li>
+        {{#if settings.gift_certificates_enabled}}
+            <li class="navPages-item">
+                <a class="navPages-action" href="{{urls.gift_certificate.purchase}}">{{lang 'common.gift_cert'}}</a>
+            </li>
+        {{/if}}
         {{#if customer.store_credit.value '>' 0}}
             <li class="navPages-item">
                 <a class="navPages-action navPages-action--storeCredit">


### PR DESCRIPTION
For the mobile menu add check to make sure if gift certificate is enabled before showing the gift certificate link.

@bigcommerce/stencil-team @mcampa @mjschock 