### PR TITLE
STENCIL-2491 Fix mobile search dropdown style

### DIFF
--- a/assets/scss/components/stencil/search/_search.scss
+++ b/assets/scss/components/stencil/search/_search.scss
@@ -26,14 +26,14 @@
 .quickSearchResults {
     margin-top: spacing("single");
 
-    .modal-close {
-        display: none;
-    }
-
     @include breakpoint("medium") {
         margin-top: 0;
+    }
 
-        .modal-close {
+    .modal-close {
+        display: none;
+
+        @include breakpoint("medium") {
             display: block;
         }
     }

--- a/assets/scss/components/stencil/search/_search.scss
+++ b/assets/scss/components/stencil/search/_search.scss
@@ -23,6 +23,22 @@
     }
 }
 
+.quickSearchResults {
+    margin-top: spacing("single");
+
+    .modal-close {
+        display: none;
+    }
+
+    @include breakpoint("medium") {
+        margin-top: 0;
+
+        .modal-close {
+            display: block;
+        }
+    }
+}
+
 .advancedSearch-separator {
     display: none;
 }


### PR DESCRIPTION
Don't need to show the close button because there is one in the top left corner already

https://jira.bigcommerce.com/browse/STENCIL-2491

## Before:
![image](https://cloud.githubusercontent.com/assets/1934727/22671487/67ae9fce-ec83-11e6-8b41-009205f7f0a4.png)


## After:
![image](https://cloud.githubusercontent.com/assets/1934727/22671464/54e93a66-ec83-11e6-963d-0edcddc3bfc5.png)


@bc-AlyssNoland @mjschock @bc-ong 