### PR TITLE
STENCIL-3084 - fix z-index on product sale badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Make sure product review email links automatically pop the review form [#928](https://github.com/bigcommerce/stencil/pull/928)
 - Fixes an issue where search results would incorrectly state there were no results when there were results visible [#934](https://github.com/bigcommerce/stencil/pull/934)
 - Update BC logo sprite to use current BC logo [#931](https://github.com/bigcommerce/stencil/pull/931)
+- Fix z-index for product sale badges so they aren't above the menu [#926](https://github.com/bigcommerce/stencil/pull/926)
+
 
 ## 1.5.2 (2017-02-14)
 - Added a setting to theme editor schema to show/hide the homepage carousel [#909](https://github.com/bigcommerce/stencil/pull/909)

--- a/assets/scss/layouts/products/_productSaleBadges.scss
+++ b/assets/scss/layouts/products/_productSaleBadges.scss
@@ -44,7 +44,7 @@
     text-align: center;
     top: 20%;
     width: rem-calc(50px);
-    z-index: zIndex("low");
+    z-index: zIndex("lower");
 }
 
 // -----------------------------------------------------------------------------
@@ -64,7 +64,7 @@
     padding-top: spacing("eighth") / 2;
     position: absolute;
     transition: 800ms ease;
-    z-index: zIndex("low");
+    z-index: zIndex("lower");
 }
 
 .product:hover .sale-flag-side {
@@ -91,7 +91,7 @@
     transform: rotate(-45deg);
     transition: 800ms ease;
     width: rem-calc(119px);
-    z-index: zIndex("low");
+    z-index: zIndex("lower");
 }
 
 .product:hover .sale-flag-sash {


### PR DESCRIPTION
Sale badges can appear on top of the megamenu if it comes down far
enough. This is due to a bad z-index.

Proof:
Star Sale Badge
![image](https://cloud.githubusercontent.com/assets/8922457/23095993/ea6e7b16-f5c8-11e6-879d-fb05205b75dd.png)
Diagonal Sale Badge
![image](https://cloud.githubusercontent.com/assets/8922457/23095997/061166a8-f5c9-11e6-8e0e-34a3471a39d8.png)
Top Left Sale Badge
![image](https://cloud.githubusercontent.com/assets/8922457/23096006/1f1b5168-f5c9-11e6-88ef-ef380009141c.png)
