### PR TITLE
STENCIL-2629 - Remove option for "disable" on number of products per page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Auto-expand product videos on the product page if the product has at least one video [#935](https://github.com/bigcommerce/stencil/pull/935)
 - Fix an issue with special characters in search results for content pages [#933](https://github.com/bigcommerce/stencil/pull/933)
 - Fix an issue with special characters in carousel text [#932](https://github.com/bigcommerce/stencil/pull/932)
+- Remove an unnecessary and confusing option in theme editor [#927](https://github.com/bigcommerce/stencil/pull/927)
 
 
 ## 1.5.2 (2017-02-14)

--- a/schema.json
+++ b/schema.json
@@ -1280,10 +1280,6 @@
         "force_reload": true,
         "options": [
           {
-            "value": 0,
-            "label": "Disable"
-          },
-          {
             "value": 6,
             "label": "6"
           },
@@ -1328,10 +1324,6 @@
         "force_reload": true,
         "options": [
           {
-            "value": 0,
-            "label": "Disable"
-          },
-          {
             "value": 6,
             "label": "6"
           },
@@ -1375,10 +1367,6 @@
         "id": "searchpage_products_per_page",
         "force_reload": true,
         "options": [
-          {
-            "value": 0,
-            "label": "Disable"
-          },
           {
             "value": 6,
             "label": "6"


### PR DESCRIPTION
We have this weird option for "disabling" the number of products per page, which makes no sense and is causing confusion.

In the future we may evaluate some kind of best practice for infinite scrolling, but for now we should disable this.

Proof:
![image](https://cloud.githubusercontent.com/assets/8922457/23096388/5af445e4-f5d0-11e6-8a56-b7fc1b315dc9.png)
