### PR TITLE
STENCIL-2493 - Do not display "none" option for required pick lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix an issue with special characters in search results for content pages [#933](https://github.com/bigcommerce/stencil/pull/933)
 - Fix an issue with special characters in carousel text [#932](https://github.com/bigcommerce/stencil/pull/932)
 - Remove an unnecessary and confusing option in theme editor [#927](https://github.com/bigcommerce/stencil/pull/927)
+- Fix an issue where required product list options would display an invalid "none" choice [#929](https://github.com/bigcommerce/stencil/pull/929)
 
 
 ## 1.5.2 (2017-02-14)

--- a/templates/components/products/options/product-list.html
+++ b/templates/components/products/options/product-list.html
@@ -43,14 +43,15 @@
             {{/each}}
         </ul>
     {{else}}
+        {{#unless required}}
         <input class="form-radio"
                type="radio"
                name="attribute[{{id}}]"
                value="0"
                id="attribute_0_{{id}}"
                {{#if defaultValue '==' 0}}checked{{/if}}
-               {{#if required}}required{{/if}}>
         <label class="form-label" for="attribute_0_{{id}}">{{lang 'products.none'}}</label>
+        {{/unless}}
         {{#each values}}
             <input
                 class="form-radio"


### PR DESCRIPTION
Correctly hiding the “none” option for required pick lists (without
photo)

I've also verified that this works with and without a default selection on the option.

Proof:

![image](https://cloud.githubusercontent.com/assets/8922457/23096851/40d3fbe6-f5da-11e6-84ca-65a47764be0a.png)
