### PR TITLE
STENCIL-2494 - don't over-escape carousel content text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix z-index for product sale badges so they aren't above the menu [#926](https://github.com/bigcommerce/stencil/pull/926)
 - Auto-expand product videos on the product page if the product has at least one video [#935](https://github.com/bigcommerce/stencil/pull/935)
 - Fix an issue with special characters in search results for content pages [#933](https://github.com/bigcommerce/stencil/pull/933)
+- Fix an issue with special characters in carousel text [#932](https://github.com/bigcommerce/stencil/pull/932)
 
 
 ## 1.5.2 (2017-02-14)

--- a/templates/components/carousel-content.html
+++ b/templates/components/carousel-content.html
@@ -1,6 +1,6 @@
 <div class="heroCarousel-content{{#unless show_background}} heroCarousel-content--empty{{/unless}}">
-    <h1 class="heroCarousel-title">{{heading}}</h1>
-    <p class="heroCarousel-description">{{text}}</p>
+    <h1 class="heroCarousel-title">{{{heading}}}</h1>
+    <p class="heroCarousel-description">{{{text}}}</p>
     {{#if button_text}}
         <span class="heroCarousel-action button button--primary button--large">{{button_text}}</span>
     {{/if}}


### PR DESCRIPTION
Using triple braces for text content on Carousel so it doesn't get over-escaped.

Generally we don't consider this a security risk as the content must be entered by the merchant in the control panel.

Proof:
(Before)
![image](https://cloud.githubusercontent.com/assets/8922457/23098149/00150f74-f5fc-11e6-9811-c9eddd7eab08.png)

(After)
![image](https://cloud.githubusercontent.com/assets/8922457/23098150/0c7718f2-f5fc-11e6-8522-107768145e30.png)
