### PR TITLE
STENCIL-2415 - Prevent over-escaping of HTML in content page search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Update BC logo sprite to use current BC logo [#931](https://github.com/bigcommerce/stencil/pull/931)
 - Fix z-index for product sale badges so they aren't above the menu [#926](https://github.com/bigcommerce/stencil/pull/926)
 - Auto-expand product videos on the product page if the product has at least one video [#935](https://github.com/bigcommerce/stencil/pull/935)
+- Fix an issue with special characters in search results for content pages [#933](https://github.com/bigcommerce/stencil/pull/933)
 
 
 ## 1.5.2 (2017-02-14)

--- a/templates/pages/search.html
+++ b/templates/pages/search.html
@@ -132,8 +132,8 @@ product_results:
                 {{> components/search/content-sort-box sort=pagination.content_results.sort}}
                 <ul>
                     {{#each content_results}}
-                        <strong><a href="{{url}}">{{title}}</a></strong>({{type}})
-                        <p>{{content}}</p>
+                        <strong><a href="{{url}}">{{{title}}}</a></strong>({{type}})
+                        <p>{{{content}}}</p>
                     {{/each}}
                 </ul>
                 {{> components/common/paginator pagination.content_results reload=true}}


### PR DESCRIPTION
Page content and titles are entered by merchants in the CP so they can be safely rendered raw, without escaping.

Note that I tested some light script injection and nothing worked, including with Raw HTML pages. However, we will want to be able to detect those since they don't look nice visually.

Proof:
![image](https://cloud.githubusercontent.com/assets/8922457/23098278/bd153142-f5fe-11e6-9350-49b7d42c5f43.png)
![image](https://cloud.githubusercontent.com/assets/8922457/23098279/c949e2be-f5fe-11e6-8ccc-407390ae27d9.png)

![image](https://cloud.githubusercontent.com/assets/8922457/23098351/d4fb3346-f5ff-11e6-8b30-540e83241e64.png)
