### PR TITLE
STENCIL-2445: Remove unused variable causing js error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fix an issue with special characters in carousel text [#932](https://github.com/bigcommerce/stencil/pull/932)
 - Remove an unnecessary and confusing option in theme editor [#927](https://github.com/bigcommerce/stencil/pull/927)
 - Fix an issue where required product list options would display an invalid "none" choice [#929](https://github.com/bigcommerce/stencil/pull/929)
-
+- Remove unused variable causing js error with search in the nav [#938](https://github.com/bigcommerce/stencil/pull/938)
 
 ## 1.5.2 (2017-02-14)
 - Added a setting to theme editor schema to show/hide the homepage carousel [#909](https://github.com/bigcommerce/stencil/pull/909)

--- a/assets/js/theme/global/stencil-dropdown.js
+++ b/assets/js/theme/global/stencil-dropdown.js
@@ -16,7 +16,7 @@ export default class StencilDropdown {
 
         // callback "hide"
         if (this.extendables && this.extendables.hide) {
-            this.extendables.hide(event);
+            this.extendables.hide();
         }
 
         $dropDown.removeClass('is-open f-open-dropdown').attr('aria-hidden', 'true');


### PR DESCRIPTION
Unused event variable was causing js errors in Firefox and preventing execution of the rest of the function.

@mcampa @mjschock 