### PR TITLE
STENCIL-3190 add customized_checkout feature to theme feature list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Remove unused variable causing js error with search in the nav [#938](https://github.com/bigcommerce/stencil/pull/938)
 - Add settings to theme editor schema to customize Optimized Checkout discount banners [#924] (https://github.com/bigcommerce/stencil/pull/924)
 - Update Optimized Checkout discount banners default values per theme variation [#942] (https://github.com/bigcommerce/stencil/pull/942)
+- Add customized checkout feature to features array [#880] (https://github.com/bigcommerce/stencil/pull/880)
 
 ## 1.5.2 (2017-02-14)
 - Added a setting to theme editor schema to show/hide the homepage carousel [#909](https://github.com/bigcommerce/stencil/pull/909)

--- a/config.json
+++ b/config.json
@@ -28,6 +28,7 @@
       "product_showcase",
       "persistent_cart",
       "one_page_check_out",
+      "customized_checkout",
       "product_videos"
     ]
   },


### PR DESCRIPTION
## What
as per title ^

<img width="1439" alt="screen shot 2017-02-22 at 2 38 13 pm" src="https://cloud.githubusercontent.com/assets/8165665/23196265/95dffd1c-f90c-11e6-8174-f39e13715b22.png">

## Why
to serve checkout.html from the stencil template itself https://github.com/bigcommerce/stencil/blob/master/templates/pages/checkout.html.
Related PR https://github.com/bigcommerce/stencil/pull/880

## Testing
https://store-vbf2yxgg1v.my-integration.zone/
theme bundle -> [Cornerstone-1.5.2.zip](https://github.com/bigcommerce/stencil/files/792175/Cornerstone-1.5.2.zip)

@bigcommerce/checkout @bigcommerce/stencil-team 