### PR TITLE
CHECKOUT-1561: style discountBanners for Cornerstone theme variations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix an issue where required product list options would display an invalid "none" choice [#929](https://github.com/bigcommerce/stencil/pull/929)
 - Remove unused variable causing js error with search in the nav [#938](https://github.com/bigcommerce/stencil/pull/938)
 - Add settings to theme editor schema to customize Optimized Checkout discount banners [#924] (https://github.com/bigcommerce/stencil/pull/924)
+- Update Optimized Checkout discount banners default values per theme variation [#942] (https://github.com/bigcommerce/stencil/pull/942)
 
 ## 1.5.2 (2017-02-14)
 - Added a setting to theme editor schema to show/hide the homepage carousel [#909](https://github.com/bigcommerce/stencil/pull/909)

--- a/assets/scss/optimized-checkout.scss
+++ b/assets/scss/optimized-checkout.scss
@@ -191,6 +191,8 @@ a {
 .optimizedCheckout-discountBanner {
     background-color: stencilColor("optimizedCheckout-discountBanner-backgroundColor");
     color: stencilColor("optimizedCheckout-discountBanner-textColor");
+    font-family: stencilFontFamily("optimizedCheckout-link-font"), Arial, Helvetica, sans-serif;
+    font-weight: stencilFontWeight("optimizedCheckout-link-font");
 
     svg {
         fill: stencilColor("optimizedCheckout-discountBanner-iconColor");

--- a/config.json
+++ b/config.json
@@ -585,6 +585,7 @@
         "optimizedCheckout-buttonSecondary-borderColor": "#d6cdc1",
         "optimizedCheckout-link-color": "#74685c",
         "optimizedCheckout-link-font": "Google_Roboto_400",
+        "optimizedCheckout-discountBanner-backgroundColor": "#F2EEE9",
         "optimizedCheckout-orderSummary-backgroundColor": "#ffffff",
         "optimizedCheckout-step-backgroundColor": "#5c5245",
         "optimizedCheckout-step-textColor": "#ffffff",


### PR DESCRIPTION
#### What?

add font styles and background color for discount banners for Cornerstone theme variations

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/CHECKOUT-1561

#### Screenshots (if appropriate)

<img width="1440" alt="screen shot 2017-02-23 at 5 02 04 pm" src="https://cloud.githubusercontent.com/assets/8165665/23246742/d524cd4e-f9e9-11e6-8866-c01e44949748.png">

#### Testing
theme bundle: [Cornerstone-1.5.2.zip](https://github.com/bigcommerce/stencil/files/795668/Cornerstone-1.5.2.zip)

https://launchbay.bigcommerce.net/projects/1/releases/27254 -> https://store-k8ndry7kvg.my-integration.zone/

@bigcommerce/checkout @bigcommerce/stencil-team 

